### PR TITLE
:sparkles: Implement ListFormat class

### DIFF
--- a/doc/list.md
+++ b/doc/list.md
@@ -1,0 +1,138 @@
+# ListFormat
+
+Locale-aware list formatting. Equivalent to JavaScript's Intl.ListFormat.
+
+---
+
+## Class Structure
+
+```
+ICU4X
+└─ ListFormat
+```
+
+---
+
+## ICU4X::ListFormat
+
+A class for formatting lists of strings according to locale conventions.
+
+### Interface
+
+```ruby
+module ICU4X
+  class ListFormat
+    # Constructor
+    # @param locale [Locale] Locale
+    # @param provider [DataProvider] Data provider
+    # @param type [Symbol] :conjunction (default), :disjunction, or :unit
+    # @param style [Symbol] :long (default), :short, or :narrow
+    # @raise [ArgumentError] If type or style is invalid
+    # @raise [Error] If data loading fails
+    def initialize(locale, provider:, type: :conjunction, style: :long) = ...
+
+    # Format a list
+    # @param list [Array<String>] Array of strings to format
+    # @return [String]
+    # @raise [TypeError] If list is not an Array
+    def format(list) = ...
+
+    # Get resolved options
+    # @return [Hash]
+    def resolved_options = ...
+  end
+end
+```
+
+---
+
+## type Option
+
+| Value | Description | Example (en) |
+|-------|-------------|--------------|
+| `:conjunction` | "and" list (default) | "A, B, and C" |
+| `:disjunction` | "or" list | "A, B, or C" |
+| `:unit` | Unit list (no conjunction) | "A, B, C" |
+
+---
+
+## style Option
+
+| Value | Description | Example (:conjunction, en) |
+|-------|-------------|----------------------------|
+| `:long` | Full format (default) | "A, B, and C" |
+| `:short` | Shorter format | "A, B, & C" |
+| `:narrow` | Minimal format | "A, B, C" |
+
+---
+
+## Usage Examples
+
+### Basic List Formatting
+
+```ruby
+provider = ICU4X::DataProvider.from_blob(Pathname.new("data/i18n.blob"))
+locale = ICU4X::Locale.parse("en-US")
+
+lf = ICU4X::ListFormat.new(locale, provider: provider)
+
+lf.format(["Apple", "Orange", "Banana"])
+# => "Apple, Orange, and Banana"
+
+lf.format(["Red", "Blue"])
+# => "Red and Blue"
+
+lf.format(["Single"])
+# => "Single"
+```
+
+### Disjunction (Or)
+
+```ruby
+lf = ICU4X::ListFormat.new(locale, provider: provider, type: :disjunction)
+
+lf.format(["Monday", "Tuesday", "Wednesday"])
+# => "Monday, Tuesday, or Wednesday"
+```
+
+### Unit List
+
+```ruby
+lf = ICU4X::ListFormat.new(locale, provider: provider, type: :unit)
+
+lf.format(["5 pounds", "3 ounces"])
+# => "5 pounds, 3 ounces"
+```
+
+### Japanese Locale
+
+```ruby
+locale_ja = ICU4X::Locale.parse("ja")
+lf = ICU4X::ListFormat.new(locale_ja, provider: provider)
+
+lf.format(["りんご", "みかん", "バナナ"])
+# => "りんご、みかん、バナナ"
+```
+
+### Style Variations
+
+```ruby
+# Short style
+lf_short = ICU4X::ListFormat.new(locale, provider: provider, style: :short)
+lf_short.format(["A", "B", "C"])
+# => "A, B, & C"
+
+# Narrow style
+lf_narrow = ICU4X::ListFormat.new(locale, provider: provider, style: :narrow)
+lf_narrow.format(["A", "B", "C"])
+# => "A, B, C"
+```
+
+---
+
+## Notes
+
+- Empty arrays return an empty string
+- Single-item arrays return the item as-is
+- Two-item arrays use the appropriate conjunction without a comma
+- List separator patterns vary by locale (e.g., Japanese uses "、" instead of ",")

--- a/ext/icu4x/src/lib.rs
+++ b/ext/icu4x/src/lib.rs
@@ -1,6 +1,7 @@
 mod data_generator;
 mod data_provider;
 mod datetime_format;
+mod list_format;
 mod locale;
 mod number_format;
 mod plural_rules;
@@ -17,6 +18,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     plural_rules::init(ruby, &module)?;
     number_format::init(ruby, &module)?;
     datetime_format::init(ruby, &module)?;
+    list_format::init(ruby, &module)?;
 
     Ok(())
 }

--- a/ext/icu4x/src/list_format.rs
+++ b/ext/icu4x/src/list_format.rs
@@ -1,0 +1,236 @@
+use crate::data_provider::DataProvider;
+use crate::locale::Locale;
+use icu::list::options::{ListFormatterOptions, ListLength};
+use icu::list::ListFormatter;
+use icu_provider::buf::AsDeserializingBufferProvider;
+use magnus::{
+    function, method, prelude::*, Error, ExceptionClass, RArray, RHash, RModule, Ruby, Symbol,
+    TryConvert, Value,
+};
+
+/// The type of list formatting
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ListType {
+    Conjunction,
+    Disjunction,
+    Unit,
+}
+
+impl ListType {
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            ListType::Conjunction => "conjunction",
+            ListType::Disjunction => "disjunction",
+            ListType::Unit => "unit",
+        }
+    }
+}
+
+/// The style of list formatting
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ListStyle {
+    Long,
+    Short,
+    Narrow,
+}
+
+impl ListStyle {
+    fn to_list_length(self) -> ListLength {
+        match self {
+            ListStyle::Long => ListLength::Wide,
+            ListStyle::Short => ListLength::Short,
+            ListStyle::Narrow => ListLength::Narrow,
+        }
+    }
+
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            ListStyle::Long => "long",
+            ListStyle::Short => "short",
+            ListStyle::Narrow => "narrow",
+        }
+    }
+}
+
+/// Ruby wrapper for ICU4X ListFormatter
+#[magnus::wrap(class = "ICU4X::ListFormat", free_immediately, size)]
+pub struct ListFormat {
+    inner: ListFormatter,
+    locale_str: String,
+    list_type: ListType,
+    list_style: ListStyle,
+}
+
+// SAFETY: Ruby's GVL protects access to this type.
+unsafe impl Send for ListFormat {}
+
+impl ListFormat {
+    /// Create a new ListFormat instance
+    ///
+    /// # Arguments
+    /// * `locale` - A Locale instance
+    /// * `provider:` - A DataProvider instance
+    /// * `type:` - :conjunction (default), :disjunction, or :unit
+    /// * `style:` - :long (default), :short, or :narrow
+    fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
+        // Parse arguments: (locale, **kwargs)
+        if args.is_empty() {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "wrong number of arguments (given 0, expected 1+)",
+            ));
+        }
+
+        // Get the locale
+        let locale: &Locale = TryConvert::try_convert(args[0])?;
+        let locale_ref = locale.inner.borrow();
+        let locale_str = locale_ref.to_string();
+        let icu_locale = locale_ref.clone();
+        drop(locale_ref);
+
+        // Get kwargs
+        let kwargs: RHash = if args.len() > 1 {
+            TryConvert::try_convert(args[1])?
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "missing keyword: :provider",
+            ));
+        };
+
+        // Extract provider (required)
+        let provider_value: Value = kwargs
+            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
+            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+
+        // Extract type option (default: :conjunction)
+        let type_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("type"))?;
+        let conjunction_sym = ruby.to_symbol("conjunction");
+        let disjunction_sym = ruby.to_symbol("disjunction");
+        let unit_sym = ruby.to_symbol("unit");
+        let type_sym = type_value.unwrap_or(conjunction_sym);
+
+        let list_type = if type_sym.equal(conjunction_sym)? {
+            ListType::Conjunction
+        } else if type_sym.equal(disjunction_sym)? {
+            ListType::Disjunction
+        } else if type_sym.equal(unit_sym)? {
+            ListType::Unit
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "type must be :conjunction, :disjunction, or :unit",
+            ));
+        };
+
+        // Extract style option (default: :long)
+        let style_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("style"))?;
+        let long_sym = ruby.to_symbol("long");
+        let short_sym = ruby.to_symbol("short");
+        let narrow_sym = ruby.to_symbol("narrow");
+        let style_sym = style_value.unwrap_or(long_sym);
+
+        let list_style = if style_sym.equal(long_sym)? {
+            ListStyle::Long
+        } else if style_sym.equal(short_sym)? {
+            ListStyle::Short
+        } else if style_sym.equal(narrow_sym)? {
+            ListStyle::Narrow
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "style must be :long, :short, or :narrow",
+            ));
+        };
+
+        // Get the error exception class
+        let error_class: ExceptionClass = ruby
+            .eval("ICU4X::Error")
+            .unwrap_or_else(|_| ruby.exception_runtime_error());
+
+        // Get the DataProvider
+        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+            Error::new(
+                ruby.exception_type_error(),
+                "provider must be a DataProvider",
+            )
+        })?;
+
+        // Build formatter options
+        let options = ListFormatterOptions::default().with_length(list_style.to_list_length());
+
+        // Create formatter based on type
+        let prefs = (&icu_locale).into();
+        let formatter = match list_type {
+            ListType::Conjunction => {
+                ListFormatter::try_new_and_unstable(&dp.inner.as_deserializing(), prefs, options)
+            }
+            ListType::Disjunction => {
+                ListFormatter::try_new_or_unstable(&dp.inner.as_deserializing(), prefs, options)
+            }
+            ListType::Unit => {
+                ListFormatter::try_new_unit_unstable(&dp.inner.as_deserializing(), prefs, options)
+            }
+        }
+        .map_err(|e| Error::new(error_class, format!("Failed to create ListFormat: {}", e)))?;
+
+        Ok(Self {
+            inner: formatter,
+            locale_str,
+            list_type,
+            list_style,
+        })
+    }
+
+    /// Format a list of strings
+    ///
+    /// # Arguments
+    /// * `list` - An array of strings
+    ///
+    /// # Returns
+    /// A formatted string
+    fn format(&self, list: Value) -> Result<String, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+
+        // Convert Ruby Array to Vec<String>
+        let array: RArray = TryConvert::try_convert(list)
+            .map_err(|_| Error::new(ruby.exception_type_error(), "list must be an Array"))?;
+
+        let items: Vec<String> = array
+            .into_iter()
+            .map(|v| TryConvert::try_convert(v))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let formatted = self.inner.format(items.iter().map(|s| s.as_str()));
+        Ok(formatted.to_string())
+    }
+
+    /// Get the resolved options
+    ///
+    /// # Returns
+    /// A hash with :locale, :type, and :style keys
+    fn resolved_options(&self) -> Result<RHash, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+        let hash = ruby.hash_new();
+        hash.aset(ruby.to_symbol("locale"), self.locale_str.as_str())?;
+        hash.aset(
+            ruby.to_symbol("type"),
+            ruby.to_symbol(self.list_type.to_symbol_name()),
+        )?;
+        hash.aset(
+            ruby.to_symbol("style"),
+            ruby.to_symbol(self.list_style.to_symbol_name()),
+        )?;
+        Ok(hash)
+    }
+}
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("ListFormat", ruby.class_object())?;
+    class.define_singleton_method("new", function!(ListFormat::new, -1))?;
+    class.define_method("format", method!(ListFormat::format, 1))?;
+    class.define_method("resolved_options", method!(ListFormat::resolved_options, 0))?;
+    Ok(())
+}

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -99,4 +99,23 @@ module ICU4X
       ?time_zone: String
     }
   end
+
+  type list_format_type = :conjunction | :disjunction | :unit
+  type list_format_style = :long | :short | :narrow
+
+  class ListFormat
+    def self.new: (
+      Locale locale,
+      provider: DataProvider,
+      ?type: list_format_type,
+      ?style: list_format_style
+    ) -> ListFormat
+
+    def format: (Array[String] list) -> String
+    def resolved_options: () -> {
+      locale: String,
+      type: list_format_type,
+      style: list_format_style
+    }
+  end
 end

--- a/spec/icu4x/list_format_spec.rb
+++ b/spec/icu4x/list_format_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+RSpec.describe ICU4X::ListFormat do
+  let(:fixtures_path) { Pathname.new(__dir__).parent / "fixtures" }
+  let(:valid_blob_path) { fixtures_path / "test-data.postcard" }
+
+  describe ".new" do
+    context "with DataProvider" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "creates with default options" do
+        lf = ICU4X::ListFormat.new(locale, provider:)
+
+        expect(lf).to be_a(ICU4X::ListFormat)
+      end
+
+      it "creates with type: :conjunction" do
+        lf = ICU4X::ListFormat.new(locale, provider:, type: :conjunction)
+
+        expect(lf).to be_a(ICU4X::ListFormat)
+      end
+
+      it "creates with type: :disjunction" do
+        lf = ICU4X::ListFormat.new(locale, provider:, type: :disjunction)
+
+        expect(lf).to be_a(ICU4X::ListFormat)
+      end
+
+      it "creates with type: :unit" do
+        lf = ICU4X::ListFormat.new(locale, provider:, type: :unit)
+
+        expect(lf).to be_a(ICU4X::ListFormat)
+      end
+
+      it "creates with style: :short" do
+        lf = ICU4X::ListFormat.new(locale, provider:, style: :short)
+
+        expect(lf).to be_a(ICU4X::ListFormat)
+      end
+
+      it "creates with style: :narrow" do
+        lf = ICU4X::ListFormat.new(locale, provider:, style: :narrow)
+
+        expect(lf).to be_a(ICU4X::ListFormat)
+      end
+    end
+
+    context "with invalid arguments" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "raises ArgumentError when missing provider keyword" do
+        expect { ICU4X::ListFormat.new(locale) }
+          .to raise_error(ArgumentError, /missing keyword: :provider/)
+      end
+
+      it "raises ArgumentError for invalid type" do
+        expect { ICU4X::ListFormat.new(locale, provider:, type: :invalid) }
+          .to raise_error(ArgumentError, /type must be :conjunction, :disjunction, or :unit/)
+      end
+
+      it "raises ArgumentError for invalid style" do
+        expect { ICU4X::ListFormat.new(locale, provider:, style: :invalid) }
+          .to raise_error(ArgumentError, /style must be :long, :short, or :narrow/)
+      end
+
+      it "raises TypeError when provider is invalid type" do
+        expect { ICU4X::ListFormat.new(locale, provider: "not a provider") }
+          .to raise_error(TypeError, /provider must be a DataProvider/)
+      end
+    end
+  end
+
+  describe "#format" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    context "with type: :conjunction (default)" do
+      let(:lf) { ICU4X::ListFormat.new(ICU4X::Locale.parse("en"), provider:) }
+
+      it "formats empty array" do
+        expect(lf.format([])).to eq("")
+      end
+
+      it "formats single item" do
+        expect(lf.format(["A"])).to eq("A")
+      end
+
+      it "formats two items" do
+        expect(lf.format(%w[A B])).to eq("A and B")
+      end
+
+      it "formats three items" do
+        expect(lf.format(%w[A B C])).to eq("A, B, and C")
+      end
+    end
+
+    context "with type: :disjunction" do
+      let(:lf) { ICU4X::ListFormat.new(ICU4X::Locale.parse("en"), provider:, type: :disjunction) }
+
+      it "formats with or" do
+        expect(lf.format(%w[A B C])).to eq("A, B, or C")
+      end
+
+      it "formats two items with or" do
+        expect(lf.format(%w[A B])).to eq("A or B")
+      end
+    end
+
+    context "with type: :unit" do
+      let(:lf) { ICU4X::ListFormat.new(ICU4X::Locale.parse("en"), provider:, type: :unit) }
+
+      it "formats without conjunction" do
+        expect(lf.format(["5 pounds", "3 ounces"])).to eq("5 pounds, 3 ounces")
+      end
+    end
+
+    context "with Japanese locale" do
+      let(:lf) { ICU4X::ListFormat.new(ICU4X::Locale.parse("ja"), provider:) }
+
+      it "formats in Japanese style" do
+        expect(lf.format(%w[A B C])).to eq("A、B、C")
+      end
+    end
+
+    context "with German locale" do
+      let(:lf) { ICU4X::ListFormat.new(ICU4X::Locale.parse("de"), provider:) }
+
+      it "formats with und" do
+        expect(lf.format(%w[A B C])).to eq("A, B und C")
+      end
+    end
+
+    context "with style variations" do
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "formats with short style" do
+        lf = ICU4X::ListFormat.new(locale, provider:, style: :short)
+
+        expect(lf.format(%w[A B C])).to eq("A, B, & C")
+      end
+
+      it "formats with narrow style" do
+        lf = ICU4X::ListFormat.new(locale, provider:, style: :narrow)
+
+        expect(lf.format(%w[A B C])).to eq("A, B, C")
+      end
+    end
+
+    context "with invalid input" do
+      let(:lf) { ICU4X::ListFormat.new(ICU4X::Locale.parse("en"), provider:) }
+
+      it "raises TypeError for non-array input" do
+        expect { lf.format("not an array") }.to raise_error(TypeError, /list must be an Array/)
+      end
+    end
+  end
+
+  describe "#resolved_options" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    it "returns hash with locale, type, style for defaults" do
+      lf = ICU4X::ListFormat.new(ICU4X::Locale.parse("en"), provider:)
+
+      expect(lf.resolved_options).to eq({locale: "en", type: :conjunction, style: :long})
+    end
+
+    it "returns hash with specified type and style" do
+      lf = ICU4X::ListFormat.new(
+        ICU4X::Locale.parse("ja"),
+        provider:,
+        type: :disjunction,
+        style: :short
+      )
+
+      expect(lf.resolved_options).to eq({locale: "ja", type: :disjunction, style: :short})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add ListFormat class for locale-aware list formatting, equivalent to JavaScript's Intl.ListFormat.

## Changes
- Implement ListFormat in Rust with conjunction, disjunction, and unit types
- Add RSpec tests covering all formatting options
- Add RBS type definitions
- Add documentation in doc/list.md

## Test Plan
- All 199 tests pass including 24 new ListFormat tests
- RuboCop passes with no offenses

Closes #2
