### PR TITLE
:sparkles: Implement Collator class

### DIFF
--- a/doc/collator.md
+++ b/doc/collator.md
@@ -1,0 +1,161 @@
+# Collator
+
+Locale-aware string comparison. Equivalent to JavaScript's Intl.Collator.
+
+---
+
+## Class Structure
+
+```
+ICU4X
+└─ Collator
+```
+
+---
+
+## ICU4X::Collator
+
+A class for comparing strings according to locale-specific rules.
+
+### Interface
+
+```ruby
+module ICU4X
+  class Collator
+    # Constructor
+    # @param locale [Locale] Locale
+    # @param provider [DataProvider] Data provider
+    # @param sensitivity [Symbol] :base, :accent, :case, or :variant (default)
+    # @param numeric [Boolean] Enable numeric sorting (default: false)
+    # @param case_first [Symbol] :upper, :lower, or nil (default)
+    # @raise [ArgumentError] If sensitivity or case_first is invalid
+    # @raise [TypeError] If provider is not a DataProvider
+    # @raise [Error] If data loading fails
+    def initialize(locale, provider:, sensitivity: :variant, numeric: false, case_first: nil) = ...
+
+    # Compare two strings
+    # @param a [String] First string
+    # @param b [String] Second string
+    # @return [Integer] -1 if a < b, 0 if a == b, 1 if a > b
+    # @raise [TypeError] If arguments are not Strings
+    def compare(a, b) = ...
+
+    # Get resolved options
+    # @return [Hash]
+    def resolved_options = ...
+  end
+end
+```
+
+---
+
+## sensitivity Option
+
+| Value | Description | "a" vs "A" | "a" vs "á" |
+|-------|-------------|------------|------------|
+| `:base` | Base letters only | equal | equal |
+| `:accent` | Base + accents | equal | different |
+| `:case` | Base + case | different | equal |
+| `:variant` | All differences (default) | different | different |
+
+---
+
+## numeric Option
+
+| Value | "file2" vs "file10" |
+|-------|---------------------|
+| `false` (default) | "file2" > "file10" (lexicographic) |
+| `true` | "file2" < "file10" (numeric) |
+
+---
+
+## case_first Option
+
+| Value | Description |
+|-------|-------------|
+| `nil` (default) | Locale default |
+| `:upper` | Uppercase first |
+| `:lower` | Lowercase first |
+
+---
+
+## Usage Examples
+
+### Basic Comparison
+
+```ruby
+provider = ICU4X::DataProvider.from_blob(Pathname.new("data/i18n.blob"))
+locale = ICU4X::Locale.parse("en")
+
+collator = ICU4X::Collator.new(locale, provider: provider)
+
+collator.compare("apple", "banana")  # => -1
+collator.compare("apple", "apple")   # => 0
+collator.compare("banana", "apple")  # => 1
+```
+
+### Case-Insensitive Comparison
+
+```ruby
+collator = ICU4X::Collator.new(locale, provider: provider, sensitivity: :base)
+
+collator.compare("a", "A")  # => 0
+collator.compare("a", "á")  # => 0
+```
+
+### Numeric Sorting
+
+```ruby
+# Without numeric option (lexicographic)
+collator = ICU4X::Collator.new(locale, provider: provider)
+collator.compare("file2", "file10")  # => 1 (because "2" > "1")
+
+# With numeric option
+collator = ICU4X::Collator.new(locale, provider: provider, numeric: true)
+collator.compare("file2", "file10")  # => -1 (because 2 < 10)
+```
+
+### Sorting Arrays
+
+```ruby
+collator = ICU4X::Collator.new(locale, provider: provider)
+
+names = ["Zoe", "André", "alice", "Bob"]
+sorted = names.sort { |a, b| collator.compare(a, b) }
+# => ["alice", "André", "Bob", "Zoe"]
+
+# Case-insensitive sorting
+collator_base = ICU4X::Collator.new(locale, provider: provider, sensitivity: :base)
+sorted = names.sort { |a, b| collator_base.compare(a, b) }
+# => ["alice", "André", "Bob", "Zoe"]
+```
+
+### German Locale
+
+```ruby
+locale_de = ICU4X::Locale.parse("de")
+collator = ICU4X::Collator.new(locale_de, provider: provider)
+
+# German ä is treated as a variant of a
+collator.compare("ä", "b")  # => -1
+```
+
+### Japanese Locale
+
+```ruby
+locale_ja = ICU4X::Locale.parse("ja")
+collator = ICU4X::Collator.new(locale_ja, provider: provider)
+
+# Hiragana ordering
+collator.compare("あ", "い")  # => -1
+collator.compare("い", "う")  # => -1
+```
+
+---
+
+## Notes
+
+- The `compare` method returns standard comparison values: -1, 0, or 1
+- Use with `Array#sort` by passing a block: `array.sort { |a, b| collator.compare(a, b) }`
+- Collation rules vary significantly by locale
+- The `:case` sensitivity uses case level to detect case while ignoring accents

--- a/ext/icu4x/src/collator.rs
+++ b/ext/icu4x/src/collator.rs
@@ -1,0 +1,276 @@
+use crate::data_provider::DataProvider;
+use crate::locale::Locale;
+use icu::collator::Collator as IcuCollator;
+use icu::collator::CollatorPreferences;
+use icu::collator::options::{CaseLevel, CollatorOptions, Strength};
+use icu::collator::preferences::{CollationCaseFirst, CollationNumericOrdering};
+use icu_provider::buf::AsDeserializingBufferProvider;
+use magnus::{
+    Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
+    prelude::*,
+};
+use std::cmp::Ordering;
+
+/// Sensitivity level for collation
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Sensitivity {
+    Base,
+    Accent,
+    Case,
+    Variant,
+}
+
+impl Sensitivity {
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            Sensitivity::Base => "base",
+            Sensitivity::Accent => "accent",
+            Sensitivity::Case => "case",
+            Sensitivity::Variant => "variant",
+        }
+    }
+}
+
+/// Case first option
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CaseFirstOption {
+    Upper,
+    Lower,
+}
+
+impl CaseFirstOption {
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            CaseFirstOption::Upper => "upper",
+            CaseFirstOption::Lower => "lower",
+        }
+    }
+
+    fn to_icu_case_first(self) -> CollationCaseFirst {
+        match self {
+            CaseFirstOption::Upper => CollationCaseFirst::Upper,
+            CaseFirstOption::Lower => CollationCaseFirst::Lower,
+        }
+    }
+}
+
+/// Ruby wrapper for ICU4X Collator
+#[magnus::wrap(class = "ICU4X::Collator", free_immediately, size)]
+pub struct Collator {
+    inner: IcuCollator,
+    locale_str: String,
+    sensitivity: Sensitivity,
+    numeric: bool,
+    case_first: Option<CaseFirstOption>,
+}
+
+// SAFETY: Ruby's GVL protects access to this type.
+unsafe impl Send for Collator {}
+
+impl Collator {
+    /// Create a new Collator instance
+    ///
+    /// # Arguments
+    /// * `locale` - A Locale instance
+    /// * `provider:` - A DataProvider instance
+    /// * `sensitivity:` - :base, :accent, :case, or :variant (default)
+    /// * `numeric:` - Whether to use numeric sorting (default: false)
+    /// * `case_first:` - :upper, :lower, or nil (default)
+    fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
+        // Parse arguments: (locale, **kwargs)
+        if args.is_empty() {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "wrong number of arguments (given 0, expected 1+)",
+            ));
+        }
+
+        // Get the locale
+        let locale: &Locale = TryConvert::try_convert(args[0])?;
+        let locale_ref = locale.inner.borrow();
+        let locale_str = locale_ref.to_string();
+        let icu_locale = locale_ref.clone();
+        drop(locale_ref);
+
+        // Get kwargs
+        let kwargs: RHash = if args.len() > 1 {
+            TryConvert::try_convert(args[1])?
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "missing keyword: :provider",
+            ));
+        };
+
+        // Extract provider (required)
+        let provider_value: Value = kwargs
+            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
+            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+
+        // Extract sensitivity option (default: :variant)
+        let sensitivity_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("sensitivity"))?;
+        let base_sym = ruby.to_symbol("base");
+        let accent_sym = ruby.to_symbol("accent");
+        let case_sym = ruby.to_symbol("case");
+        let variant_sym = ruby.to_symbol("variant");
+        let sensitivity_sym = sensitivity_value.unwrap_or(variant_sym);
+
+        let sensitivity = if sensitivity_sym.equal(base_sym)? {
+            Sensitivity::Base
+        } else if sensitivity_sym.equal(accent_sym)? {
+            Sensitivity::Accent
+        } else if sensitivity_sym.equal(case_sym)? {
+            Sensitivity::Case
+        } else if sensitivity_sym.equal(variant_sym)? {
+            Sensitivity::Variant
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "sensitivity must be :base, :accent, :case, or :variant",
+            ));
+        };
+
+        // Extract numeric option (default: false)
+        let numeric: bool = kwargs
+            .lookup::<_, Option<bool>>(ruby.to_symbol("numeric"))?
+            .unwrap_or(false);
+
+        // Extract case_first option (default: nil)
+        let case_first_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("case_first"))?;
+        let upper_sym = ruby.to_symbol("upper");
+        let lower_sym = ruby.to_symbol("lower");
+
+        let case_first = if let Some(sym) = case_first_value {
+            if sym.equal(upper_sym)? {
+                Some(CaseFirstOption::Upper)
+            } else if sym.equal(lower_sym)? {
+                Some(CaseFirstOption::Lower)
+            } else {
+                return Err(Error::new(
+                    ruby.exception_arg_error(),
+                    "case_first must be :upper, :lower, or nil",
+                ));
+            }
+        } else {
+            None
+        };
+
+        // Get the error exception class
+        let error_class: ExceptionClass = ruby
+            .eval("ICU4X::Error")
+            .unwrap_or_else(|_| ruby.exception_runtime_error());
+
+        // Get the DataProvider
+        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+            Error::new(
+                ruby.exception_type_error(),
+                "provider must be a DataProvider",
+            )
+        })?;
+
+        // Build collator options (strength and case_level)
+        let mut options = CollatorOptions::default();
+
+        // Set strength based on sensitivity
+        options.strength = Some(match sensitivity {
+            Sensitivity::Base => Strength::Primary,
+            Sensitivity::Accent => Strength::Secondary,
+            Sensitivity::Case => Strength::Primary,
+            Sensitivity::Variant => Strength::Tertiary,
+        });
+
+        // Set case_level for case sensitivity
+        if matches!(sensitivity, Sensitivity::Case) {
+            options.case_level = Some(CaseLevel::On);
+        }
+
+        // Build preferences (numeric and case_first)
+        let mut prefs: CollatorPreferences = (&icu_locale).into();
+
+        if numeric {
+            prefs.numeric_ordering = Some(CollationNumericOrdering::True);
+        }
+
+        if let Some(cf) = case_first {
+            prefs.case_first = Some(cf.to_icu_case_first());
+        }
+
+        // Create collator
+        let collator = IcuCollator::try_new_unstable(&dp.inner.as_deserializing(), prefs, options)
+            .map_err(|e| Error::new(error_class, format!("Failed to create Collator: {}", e)))?;
+
+        Ok(Self {
+            inner: collator,
+            locale_str,
+            sensitivity,
+            numeric,
+            case_first,
+        })
+    }
+
+    /// Compare two strings
+    ///
+    /// # Arguments
+    /// * `a` - First string
+    /// * `b` - Second string
+    ///
+    /// # Returns
+    /// -1 if a < b, 0 if a == b, 1 if a > b
+    fn compare(&self, a: Value, b: Value) -> Result<i32, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+
+        let str_a: String = TryConvert::try_convert(a).map_err(|_| {
+            Error::new(
+                ruby.exception_type_error(),
+                "first argument must be a String",
+            )
+        })?;
+
+        let str_b: String = TryConvert::try_convert(b).map_err(|_| {
+            Error::new(
+                ruby.exception_type_error(),
+                "second argument must be a String",
+            )
+        })?;
+
+        let result = match self.inner.as_borrowed().compare(&str_a, &str_b) {
+            Ordering::Less => -1,
+            Ordering::Equal => 0,
+            Ordering::Greater => 1,
+        };
+
+        Ok(result)
+    }
+
+    /// Get the resolved options
+    ///
+    /// # Returns
+    /// A hash with :locale, :sensitivity, :numeric, and optionally :case_first
+    fn resolved_options(&self) -> Result<RHash, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+        let hash = ruby.hash_new();
+        hash.aset(ruby.to_symbol("locale"), self.locale_str.as_str())?;
+        hash.aset(
+            ruby.to_symbol("sensitivity"),
+            ruby.to_symbol(self.sensitivity.to_symbol_name()),
+        )?;
+        hash.aset(ruby.to_symbol("numeric"), self.numeric)?;
+        if let Some(cf) = self.case_first {
+            hash.aset(
+                ruby.to_symbol("case_first"),
+                ruby.to_symbol(cf.to_symbol_name()),
+            )?;
+        }
+        Ok(hash)
+    }
+}
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("Collator", ruby.class_object())?;
+    class.define_singleton_method("new", function!(Collator::new, -1))?;
+    class.define_method("compare", method!(Collator::compare, 2))?;
+    class.define_method("resolved_options", method!(Collator::resolved_options, 0))?;
+    Ok(())
+}

--- a/ext/icu4x/src/lib.rs
+++ b/ext/icu4x/src/lib.rs
@@ -1,3 +1,4 @@
+mod collator;
 mod data_generator;
 mod data_provider;
 mod datetime_format;
@@ -19,6 +20,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     number_format::init(ruby, &module)?;
     datetime_format::init(ruby, &module)?;
     list_format::init(ruby, &module)?;
+    collator::init(ruby, &module)?;
 
     Ok(())
 }

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -103,6 +103,9 @@ module ICU4X
   type list_format_type = :conjunction | :disjunction | :unit
   type list_format_style = :long | :short | :narrow
 
+  type collator_sensitivity = :base | :accent | :case | :variant
+  type collator_case_first = :upper | :lower
+
   class ListFormat
     def self.new: (
       Locale locale,
@@ -116,6 +119,24 @@ module ICU4X
       locale: String,
       type: list_format_type,
       style: list_format_style
+    }
+  end
+
+  class Collator
+    def self.new: (
+      Locale locale,
+      provider: DataProvider,
+      ?sensitivity: collator_sensitivity,
+      ?numeric: bool,
+      ?case_first: collator_case_first
+    ) -> Collator
+
+    def compare: (String a, String b) -> Integer
+    def resolved_options: () -> {
+      locale: String,
+      sensitivity: collator_sensitivity,
+      numeric: bool,
+      ?case_first: collator_case_first
     }
   end
 end

--- a/spec/icu4x/collator_spec.rb
+++ b/spec/icu4x/collator_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+RSpec.describe ICU4X::Collator do
+  let(:fixtures_path) { Pathname.new(__dir__).parent / "fixtures" }
+  let(:valid_blob_path) { fixtures_path / "test-data.postcard" }
+
+  describe ".new" do
+    context "with DataProvider" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "creates with default options" do
+        collator = ICU4X::Collator.new(locale, provider:)
+
+        expect(collator).to be_a(ICU4X::Collator)
+      end
+
+      it "creates with sensitivity: :base" do
+        collator = ICU4X::Collator.new(locale, provider:, sensitivity: :base)
+
+        expect(collator).to be_a(ICU4X::Collator)
+      end
+
+      it "creates with sensitivity: :accent" do
+        collator = ICU4X::Collator.new(locale, provider:, sensitivity: :accent)
+
+        expect(collator).to be_a(ICU4X::Collator)
+      end
+
+      it "creates with sensitivity: :case" do
+        collator = ICU4X::Collator.new(locale, provider:, sensitivity: :case)
+
+        expect(collator).to be_a(ICU4X::Collator)
+      end
+
+      it "creates with numeric: true" do
+        collator = ICU4X::Collator.new(locale, provider:, numeric: true)
+
+        expect(collator).to be_a(ICU4X::Collator)
+      end
+
+      it "creates with case_first: :upper" do
+        collator = ICU4X::Collator.new(locale, provider:, case_first: :upper)
+
+        expect(collator).to be_a(ICU4X::Collator)
+      end
+
+      it "creates with case_first: :lower" do
+        collator = ICU4X::Collator.new(locale, provider:, case_first: :lower)
+
+        expect(collator).to be_a(ICU4X::Collator)
+      end
+    end
+
+    context "with invalid arguments" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "raises ArgumentError when missing provider keyword" do
+        expect { ICU4X::Collator.new(locale) }
+          .to raise_error(ArgumentError, /missing keyword: :provider/)
+      end
+
+      it "raises ArgumentError for invalid sensitivity" do
+        expect { ICU4X::Collator.new(locale, provider:, sensitivity: :invalid) }
+          .to raise_error(ArgumentError, /sensitivity must be :base, :accent, :case, or :variant/)
+      end
+
+      it "raises ArgumentError for invalid case_first" do
+        expect { ICU4X::Collator.new(locale, provider:, case_first: :invalid) }
+          .to raise_error(ArgumentError, /case_first must be :upper, :lower, or nil/)
+      end
+
+      it "raises TypeError when provider is invalid type" do
+        expect { ICU4X::Collator.new(locale, provider: "not a provider") }
+          .to raise_error(TypeError, /provider must be a DataProvider/)
+      end
+    end
+  end
+
+  describe "#compare" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+    let(:locale) { ICU4X::Locale.parse("en") }
+    let(:collator) { ICU4X::Collator.new(locale, provider:) }
+
+    it "returns -1 when first < second" do
+      expect(collator.compare("apple", "banana")).to eq(-1)
+    end
+
+    it "returns 0 when equal" do
+      expect(collator.compare("apple", "apple")).to eq(0)
+    end
+
+    it "returns 1 when first > second" do
+      expect(collator.compare("banana", "apple")).to eq(1)
+    end
+
+    context "with sensitivity: :base" do
+      let(:collator) { ICU4X::Collator.new(locale, provider:, sensitivity: :base) }
+
+      it "ignores case differences" do
+        expect(collator.compare("a", "A")).to eq(0)
+      end
+
+      it "ignores accent differences" do
+        expect(collator.compare("a", "á")).to eq(0)
+      end
+    end
+
+    context "with sensitivity: :accent" do
+      let(:collator) { ICU4X::Collator.new(locale, provider:, sensitivity: :accent) }
+
+      it "ignores case differences" do
+        expect(collator.compare("a", "A")).to eq(0)
+      end
+
+      it "detects accent differences" do
+        expect(collator.compare("a", "á")).not_to eq(0)
+      end
+    end
+
+    context "with sensitivity: :case" do
+      let(:collator) { ICU4X::Collator.new(locale, provider:, sensitivity: :case) }
+
+      it "detects case differences" do
+        expect(collator.compare("a", "A")).not_to eq(0)
+      end
+
+      it "ignores accent differences" do
+        expect(collator.compare("a", "á")).to eq(0)
+      end
+    end
+
+    context "with numeric: true" do
+      let(:collator) { ICU4X::Collator.new(locale, provider:, numeric: true) }
+
+      it "sorts numbers numerically within strings" do
+        expect(collator.compare("file2", "file10")).to eq(-1)
+      end
+    end
+
+    context "without numeric option (default)" do
+      it "sorts numbers lexicographically" do
+        expect(collator.compare("file2", "file10")).to eq(1)
+      end
+    end
+
+    context "with German locale" do
+      let(:locale_de) { ICU4X::Locale.parse("de") }
+      let(:collator) { ICU4X::Collator.new(locale_de, provider:) }
+
+      it "handles German umlauts" do
+        # In German, ä is treated as a variant of a
+        result = collator.compare("ä", "b")
+
+        expect(result).to eq(-1)
+      end
+    end
+
+    context "with Japanese locale" do
+      let(:locale_ja) { ICU4X::Locale.parse("ja") }
+      let(:collator) { ICU4X::Collator.new(locale_ja, provider:) }
+
+      it "sorts hiragana correctly" do
+        expect(collator.compare("あ", "い")).to eq(-1)
+        expect(collator.compare("い", "う")).to eq(-1)
+      end
+    end
+
+    context "with invalid arguments" do
+      it "raises TypeError for non-string first argument" do
+        expect { collator.compare(123, "test") }
+          .to raise_error(TypeError, /first argument must be a String/)
+      end
+
+      it "raises TypeError for non-string second argument" do
+        expect { collator.compare("test", 123) }
+          .to raise_error(TypeError, /second argument must be a String/)
+      end
+    end
+  end
+
+  describe "#resolved_options" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    it "returns hash with default options" do
+      collator = ICU4X::Collator.new(ICU4X::Locale.parse("en"), provider:)
+
+      expect(collator.resolved_options).to eq({
+        locale: "en",
+        sensitivity: :variant,
+        numeric: false
+      })
+    end
+
+    it "returns hash with custom options" do
+      collator = ICU4X::Collator.new(
+        ICU4X::Locale.parse("ja"),
+        provider:,
+        sensitivity: :base,
+        numeric: true,
+        case_first: :upper
+      )
+
+      expect(collator.resolved_options).to eq({
+        locale: "ja",
+        sensitivity: :base,
+        numeric: true,
+        case_first: :upper
+      })
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add ICU4X::Collator class for locale-aware string comparison, equivalent to JavaScript's Intl.Collator.

## Changes
- Implement Collator with sensitivity, numeric, and case_first options
- Add compare method returning -1, 0, or 1
- Add resolved_options method
- Include RBS type definitions and documentation

Closes #3
