### PR TITLE
:sparkles: Implement DisplayNames class

### DIFF
--- a/doc/display_names.md
+++ b/doc/display_names.md
@@ -1,0 +1,159 @@
+# DisplayNames
+
+Locale-aware display names for languages, regions, scripts, and locales. Equivalent to JavaScript's Intl.DisplayNames.
+
+---
+
+## Class Structure
+
+```
+ICU4X
+└─ DisplayNames
+```
+
+---
+
+## ICU4X::DisplayNames
+
+A class for retrieving display names of language, region, script, and locale identifiers.
+
+### Interface
+
+```ruby
+module ICU4X
+  class DisplayNames
+    # Constructor
+    # @param locale [Locale] The locale for display names
+    # @param provider [DataProvider] Data provider
+    # @param type [Symbol] :language, :region, :script, :locale
+    # @param style [Symbol] :long (default), :short, :narrow
+    # @param fallback [Symbol] :code (default), :none
+    # @raise [ArgumentError] If type, style, or fallback is invalid
+    # @raise [Error] If data loading fails
+    def initialize(locale, provider:, type:, style: :long, fallback: :code) = ...
+
+    # Get display name for a code
+    # @param code [String] Language/region/script code, or locale string
+    # @return [String, nil] Display name, or nil when fallback: :none and not found
+    def of(code) = ...
+
+    # Get resolved options
+    # @return [Hash]
+    def resolved_options = ...
+  end
+end
+```
+
+---
+
+## type Option
+
+Required option specifying the type of display name to retrieve.
+
+| Value | Description | Example Code | Example Output (ja) |
+|-------|-------------|--------------|---------------------|
+| `:language` | Language name | "en" | "英語" |
+| `:region` | Region name | "US" | "アメリカ合衆国" |
+| `:script` | Script name | "Latn" | "ラテン文字" |
+| `:locale` | Full locale name | "en-US" | "アメリカ英語" |
+
+---
+
+## style Option
+
+Controls the length of the display name.
+
+| Value | Description |
+|-------|-------------|
+| `:long` | Full name (default) |
+| `:short` | Abbreviated |
+| `:narrow` | Minimal |
+
+---
+
+## fallback Option
+
+Controls behavior when a display name is not found.
+
+| Value | Description | Behavior for unknown code |
+|-------|-------------|---------------------------|
+| `:code` | Return code itself (default) | "xyz" → "xyz" |
+| `:none` | Return nil | "xyz" → nil |
+
+---
+
+## Usage Examples
+
+### Language Names
+
+```ruby
+provider = ICU4X::DataProvider.from_blob(Pathname.new("data/i18n.blob"))
+locale = ICU4X::Locale.parse("ja")
+
+dn = ICU4X::DisplayNames.new(locale, provider: provider, type: :language)
+
+dn.of("en")  # => "英語"
+dn.of("ja")  # => "日本語"
+dn.of("de")  # => "ドイツ語"
+```
+
+### Region Names
+
+```ruby
+dn = ICU4X::DisplayNames.new(locale, provider: provider, type: :region)
+
+dn.of("US")  # => "アメリカ合衆国"
+dn.of("JP")  # => "日本"
+dn.of("GB")  # => "イギリス"
+```
+
+### Script Names
+
+```ruby
+dn = ICU4X::DisplayNames.new(locale, provider: provider, type: :script)
+
+dn.of("Latn")  # => "ラテン文字"
+dn.of("Hant")  # => "繁体字"
+dn.of("Cyrl")  # => "キリル文字"
+```
+
+### Locale Names
+
+```ruby
+dn = ICU4X::DisplayNames.new(locale, provider: provider, type: :locale)
+
+dn.of("en-US")     # => "アメリカ英語"
+dn.of("zh-Hant")   # => "標準中国語 (繁体字)"
+dn.of("pt-BR")     # => "ポルトガル語 (ブラジル)"
+```
+
+### Fallback Behavior
+
+```ruby
+# Default: :code
+dn = ICU4X::DisplayNames.new(locale, provider: provider, type: :language)
+dn.of("xyz")  # => "xyz" (returns code when not found)
+
+# With :none
+dn = ICU4X::DisplayNames.new(locale, provider: provider, type: :language, fallback: :none)
+dn.of("xyz")  # => nil
+```
+
+### Different Locales
+
+```ruby
+# English locale
+en_locale = ICU4X::Locale.parse("en")
+dn_en = ICU4X::DisplayNames.new(en_locale, provider: provider, type: :language)
+
+dn_en.of("ja")  # => "Japanese"
+dn_en.of("en")  # => "English"
+```
+
+---
+
+## Notes
+
+- Each type requires different data markers in the blob
+- The returned display names follow CLDR conventions
+- Uses ICU4X experimental displaynames module

--- a/ext/icu4x/src/display_names.rs
+++ b/ext/icu4x/src/display_names.rs
@@ -1,0 +1,392 @@
+use crate::data_provider::DataProvider;
+use crate::locale::Locale;
+use icu::experimental::displaynames::{
+    DisplayNamesOptions, Fallback, LanguageDisplayNames, LocaleDisplayNamesFormatter,
+    RegionDisplayNames, ScriptDisplayNames, Style,
+};
+use icu_locale::LanguageIdentifier;
+use icu_provider::buf::AsDeserializingBufferProvider;
+use magnus::{
+    Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
+    prelude::*,
+};
+
+/// Display name type
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DisplayNamesType {
+    Language,
+    Region,
+    Script,
+    Locale,
+}
+
+impl DisplayNamesType {
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            DisplayNamesType::Language => "language",
+            DisplayNamesType::Region => "region",
+            DisplayNamesType::Script => "script",
+            DisplayNamesType::Locale => "locale",
+        }
+    }
+}
+
+/// Display name style
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DisplayNamesStyle {
+    Long,
+    Short,
+    Narrow,
+}
+
+impl DisplayNamesStyle {
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            DisplayNamesStyle::Long => "long",
+            DisplayNamesStyle::Short => "short",
+            DisplayNamesStyle::Narrow => "narrow",
+        }
+    }
+
+    fn to_icu_style(self) -> Style {
+        match self {
+            DisplayNamesStyle::Long => Style::Long,
+            DisplayNamesStyle::Short => Style::Short,
+            DisplayNamesStyle::Narrow => Style::Narrow,
+        }
+    }
+}
+
+/// Display name fallback option
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DisplayNamesFallback {
+    Code,
+    None,
+}
+
+impl DisplayNamesFallback {
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            DisplayNamesFallback::Code => "code",
+            DisplayNamesFallback::None => "none",
+        }
+    }
+
+    fn to_icu_fallback(self) -> Fallback {
+        match self {
+            DisplayNamesFallback::Code => Fallback::Code,
+            DisplayNamesFallback::None => Fallback::None,
+        }
+    }
+}
+
+/// Inner formatter enum to hold the different types
+enum DisplayNamesFormatter {
+    Language(LanguageDisplayNames),
+    Region(RegionDisplayNames),
+    Script(ScriptDisplayNames),
+    Locale(Box<LocaleDisplayNamesFormatter>),
+}
+
+/// Ruby wrapper for ICU4X DisplayNames
+#[magnus::wrap(class = "ICU4X::DisplayNames", free_immediately, size)]
+pub struct DisplayNames {
+    inner: DisplayNamesFormatter,
+    locale_str: String,
+    display_type: DisplayNamesType,
+    style: DisplayNamesStyle,
+    fallback: DisplayNamesFallback,
+}
+
+// SAFETY: Ruby's GVL protects access to this type.
+unsafe impl Send for DisplayNames {}
+
+impl DisplayNames {
+    /// Create a new DisplayNames instance
+    ///
+    /// # Arguments
+    /// * `locale` - A Locale instance
+    /// * `provider:` - A DataProvider instance
+    /// * `type:` - :language, :region, :script, or :locale
+    /// * `style:` - :long (default), :short, or :narrow
+    /// * `fallback:` - :code (default) or :none
+    fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
+        // Parse arguments: (locale, **kwargs)
+        if args.is_empty() {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "wrong number of arguments (given 0, expected 1+)",
+            ));
+        }
+
+        // Get the locale
+        let locale: &Locale = TryConvert::try_convert(args[0])?;
+        let locale_ref = locale.inner.borrow();
+        let locale_str = locale_ref.to_string();
+        let icu_locale = locale_ref.clone();
+        drop(locale_ref);
+
+        // Get kwargs
+        let kwargs: RHash = if args.len() > 1 {
+            TryConvert::try_convert(args[1])?
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "missing keyword: :provider",
+            ));
+        };
+
+        // Extract provider (required)
+        let provider_value: Value = kwargs
+            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
+            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+
+        // Extract type (required)
+        let type_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("type"))?;
+        let type_sym = type_value
+            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :type"))?;
+
+        let language_sym = ruby.to_symbol("language");
+        let region_sym = ruby.to_symbol("region");
+        let script_sym = ruby.to_symbol("script");
+        let locale_sym = ruby.to_symbol("locale");
+
+        let display_type = if type_sym.equal(language_sym)? {
+            DisplayNamesType::Language
+        } else if type_sym.equal(region_sym)? {
+            DisplayNamesType::Region
+        } else if type_sym.equal(script_sym)? {
+            DisplayNamesType::Script
+        } else if type_sym.equal(locale_sym)? {
+            DisplayNamesType::Locale
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "type must be :language, :region, :script, or :locale",
+            ));
+        };
+
+        // Extract style option (default: :long)
+        let style_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("style"))?;
+        let long_sym = ruby.to_symbol("long");
+        let short_sym = ruby.to_symbol("short");
+        let narrow_sym = ruby.to_symbol("narrow");
+        let style_sym = style_value.unwrap_or(long_sym);
+
+        let style = if style_sym.equal(long_sym)? {
+            DisplayNamesStyle::Long
+        } else if style_sym.equal(short_sym)? {
+            DisplayNamesStyle::Short
+        } else if style_sym.equal(narrow_sym)? {
+            DisplayNamesStyle::Narrow
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "style must be :long, :short, or :narrow",
+            ));
+        };
+
+        // Extract fallback option (default: :code)
+        let fallback_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("fallback"))?;
+        let code_sym = ruby.to_symbol("code");
+        let none_sym = ruby.to_symbol("none");
+        let fallback_sym = fallback_value.unwrap_or(code_sym);
+
+        let fallback = if fallback_sym.equal(code_sym)? {
+            DisplayNamesFallback::Code
+        } else if fallback_sym.equal(none_sym)? {
+            DisplayNamesFallback::None
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "fallback must be :code or :none",
+            ));
+        };
+
+        // Get the error exception class
+        let error_class: ExceptionClass = ruby
+            .eval("ICU4X::Error")
+            .unwrap_or_else(|_| ruby.exception_runtime_error());
+
+        // Get the DataProvider
+        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+            Error::new(
+                ruby.exception_type_error(),
+                "provider must be a DataProvider",
+            )
+        })?;
+
+        // Build options
+        let mut options = DisplayNamesOptions::default();
+        options.style = Some(style.to_icu_style());
+        options.fallback = fallback.to_icu_fallback();
+
+        // Create the appropriate formatter based on type
+        let inner = match display_type {
+            DisplayNamesType::Language => {
+                let formatter = LanguageDisplayNames::try_new_unstable(
+                    &dp.inner.as_deserializing(),
+                    (&icu_locale).into(),
+                    options,
+                )
+                .map_err(|e| {
+                    Error::new(
+                        error_class,
+                        format!("Failed to create LanguageDisplayNames: {}", e),
+                    )
+                })?;
+                DisplayNamesFormatter::Language(formatter)
+            }
+            DisplayNamesType::Region => {
+                let formatter = RegionDisplayNames::try_new_unstable(
+                    &dp.inner.as_deserializing(),
+                    (&icu_locale).into(),
+                    options,
+                )
+                .map_err(|e| {
+                    Error::new(
+                        error_class,
+                        format!("Failed to create RegionDisplayNames: {}", e),
+                    )
+                })?;
+                DisplayNamesFormatter::Region(formatter)
+            }
+            DisplayNamesType::Script => {
+                let formatter = ScriptDisplayNames::try_new_unstable(
+                    &dp.inner.as_deserializing(),
+                    (&icu_locale).into(),
+                    options,
+                )
+                .map_err(|e| {
+                    Error::new(
+                        error_class,
+                        format!("Failed to create ScriptDisplayNames: {}", e),
+                    )
+                })?;
+                DisplayNamesFormatter::Script(formatter)
+            }
+            DisplayNamesType::Locale => {
+                let formatter = LocaleDisplayNamesFormatter::try_new_unstable(
+                    &dp.inner.as_deserializing(),
+                    (&icu_locale).into(),
+                    options,
+                )
+                .map_err(|e| {
+                    Error::new(
+                        error_class,
+                        format!("Failed to create LocaleDisplayNamesFormatter: {}", e),
+                    )
+                })?;
+                DisplayNamesFormatter::Locale(Box::new(formatter))
+            }
+        };
+
+        Ok(Self {
+            inner,
+            locale_str,
+            display_type,
+            style,
+            fallback,
+        })
+    }
+
+    /// Get display name for a code
+    ///
+    /// # Arguments
+    /// * `code` - Language/region/script code, or locale string
+    ///
+    /// # Returns
+    /// Display name, or nil when fallback: :none and not found
+    fn of(&self, code: String) -> Result<Option<String>, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+
+        let result = match &self.inner {
+            DisplayNamesFormatter::Language(formatter) => {
+                // Parse the language code
+                let lang_id: LanguageIdentifier = code.parse().map_err(|_| {
+                    Error::new(
+                        ruby.exception_arg_error(),
+                        format!("Invalid language code: {}", code),
+                    )
+                })?;
+                formatter.of(lang_id.language).map(|s| s.to_string())
+            }
+            DisplayNamesFormatter::Region(formatter) => {
+                // Parse the region code
+                let region: icu_locale::subtags::Region = code.parse().map_err(|_| {
+                    Error::new(
+                        ruby.exception_arg_error(),
+                        format!("Invalid region code: {}", code),
+                    )
+                })?;
+                formatter.of(region).map(|s| s.to_string())
+            }
+            DisplayNamesFormatter::Script(formatter) => {
+                // Parse the script code
+                let script: icu_locale::subtags::Script = code.parse().map_err(|_| {
+                    Error::new(
+                        ruby.exception_arg_error(),
+                        format!("Invalid script code: {}", code),
+                    )
+                })?;
+                formatter.of(script).map(|s| s.to_string())
+            }
+            DisplayNamesFormatter::Locale(formatter) => {
+                // Parse the locale
+                let locale: icu_locale::Locale = code.parse().map_err(|_| {
+                    Error::new(
+                        ruby.exception_arg_error(),
+                        format!("Invalid locale: {}", code),
+                    )
+                })?;
+                Some(formatter.of(&locale).to_string())
+            }
+        };
+
+        // Apply fallback behavior
+        Ok(match result {
+            Some(name) => Some(name),
+            None => match self.fallback {
+                DisplayNamesFallback::Code => Some(code),
+                DisplayNamesFallback::None => None,
+            },
+        })
+    }
+
+    /// Get the resolved options
+    ///
+    /// # Returns
+    /// A hash with :locale, :type, :style, and :fallback keys
+    fn resolved_options(&self) -> Result<RHash, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+        let hash = ruby.hash_new();
+        hash.aset(ruby.to_symbol("locale"), self.locale_str.as_str())?;
+        hash.aset(
+            ruby.to_symbol("type"),
+            ruby.to_symbol(self.display_type.to_symbol_name()),
+        )?;
+        hash.aset(
+            ruby.to_symbol("style"),
+            ruby.to_symbol(self.style.to_symbol_name()),
+        )?;
+        hash.aset(
+            ruby.to_symbol("fallback"),
+            ruby.to_symbol(self.fallback.to_symbol_name()),
+        )?;
+        Ok(hash)
+    }
+}
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("DisplayNames", ruby.class_object())?;
+    class.define_singleton_method("new", function!(DisplayNames::new, -1))?;
+    class.define_method("of", method!(DisplayNames::of, 1))?;
+    class.define_method(
+        "resolved_options",
+        method!(DisplayNames::resolved_options, 0),
+    )?;
+    Ok(())
+}

--- a/ext/icu4x/src/lib.rs
+++ b/ext/icu4x/src/lib.rs
@@ -2,6 +2,7 @@ mod collator;
 mod data_generator;
 mod data_provider;
 mod datetime_format;
+mod display_names;
 mod list_format;
 mod locale;
 mod number_format;
@@ -21,6 +22,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     datetime_format::init(ruby, &module)?;
     list_format::init(ruby, &module)?;
     collator::init(ruby, &module)?;
+    display_names::init(ruby, &module)?;
 
     Ok(())
 }

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -139,4 +139,26 @@ module ICU4X
       ?case_first: collator_case_first
     }
   end
+
+  type display_names_type = :language | :region | :script | :locale
+  type display_names_style = :long | :short | :narrow
+  type display_names_fallback = :code | :none
+
+  class DisplayNames
+    def self.new: (
+      Locale locale,
+      provider: DataProvider,
+      type: display_names_type,
+      ?style: display_names_style,
+      ?fallback: display_names_fallback
+    ) -> DisplayNames
+
+    def of: (String code) -> String?
+    def resolved_options: () -> {
+      locale: String,
+      type: display_names_type,
+      style: display_names_style,
+      fallback: display_names_fallback
+    }
+  end
 end

--- a/spec/icu4x/display_names_spec.rb
+++ b/spec/icu4x/display_names_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+RSpec.describe ICU4X::DisplayNames do
+  let(:fixtures_path) { Pathname.new(__dir__).parent / "fixtures" }
+  let(:valid_blob_path) { fixtures_path / "test-data.postcard" }
+
+  describe ".new" do
+    context "with DataProvider" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("ja") }
+
+      it "creates a DisplayNames instance with type: :language" do
+        dn = ICU4X::DisplayNames.new(locale, provider:, type: :language)
+
+        expect(dn).to be_a(ICU4X::DisplayNames)
+      end
+
+      it "creates a DisplayNames instance with type: :region" do
+        dn = ICU4X::DisplayNames.new(locale, provider:, type: :region)
+
+        expect(dn).to be_a(ICU4X::DisplayNames)
+      end
+
+      it "creates a DisplayNames instance with type: :script" do
+        dn = ICU4X::DisplayNames.new(locale, provider:, type: :script)
+
+        expect(dn).to be_a(ICU4X::DisplayNames)
+      end
+
+      it "creates a DisplayNames instance with type: :locale" do
+        dn = ICU4X::DisplayNames.new(locale, provider:, type: :locale)
+
+        expect(dn).to be_a(ICU4X::DisplayNames)
+      end
+
+      it "creates a DisplayNames instance with style: :short" do
+        dn = ICU4X::DisplayNames.new(locale, provider:, type: :language, style: :short)
+
+        expect(dn).to be_a(ICU4X::DisplayNames)
+      end
+
+      it "creates a DisplayNames instance with style: :narrow" do
+        dn = ICU4X::DisplayNames.new(locale, provider:, type: :language, style: :narrow)
+
+        expect(dn).to be_a(ICU4X::DisplayNames)
+      end
+
+      it "creates a DisplayNames instance with fallback: :none" do
+        dn = ICU4X::DisplayNames.new(locale, provider:, type: :language, fallback: :none)
+
+        expect(dn).to be_a(ICU4X::DisplayNames)
+      end
+    end
+
+    context "with invalid arguments" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("ja") }
+
+      it "raises ArgumentError when missing provider keyword" do
+        expect { ICU4X::DisplayNames.new(locale, type: :language) }
+          .to raise_error(ArgumentError, /missing keyword: :provider/)
+      end
+
+      it "raises ArgumentError when missing type keyword" do
+        expect { ICU4X::DisplayNames.new(locale, provider:) }
+          .to raise_error(ArgumentError, /missing keyword: :type/)
+      end
+
+      it "raises ArgumentError when type is invalid" do
+        expect { ICU4X::DisplayNames.new(locale, provider:, type: :invalid) }
+          .to raise_error(ArgumentError, /type must be :language, :region, :script, or :locale/)
+      end
+
+      it "raises ArgumentError when style is invalid" do
+        expect { ICU4X::DisplayNames.new(locale, provider:, type: :language, style: :invalid) }
+          .to raise_error(ArgumentError, /style must be :long, :short, or :narrow/)
+      end
+
+      it "raises ArgumentError when fallback is invalid" do
+        expect { ICU4X::DisplayNames.new(locale, provider:, type: :language, fallback: :invalid) }
+          .to raise_error(ArgumentError, /fallback must be :code or :none/)
+      end
+
+      it "raises TypeError when provider is invalid type" do
+        expect { ICU4X::DisplayNames.new(locale, provider: "not a provider", type: :language) }
+          .to raise_error(TypeError, /provider must be a DataProvider/)
+      end
+    end
+  end
+
+  describe "#of" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    context "with type: :language" do
+      let(:dn) { ICU4X::DisplayNames.new(ICU4X::Locale.parse("ja"), provider:, type: :language) }
+
+      it "returns display name for known language code 'en'" do
+        expect(dn.of("en")).to eq("英語")
+      end
+
+      it "returns display name for known language code 'ja'" do
+        expect(dn.of("ja")).to eq("日本語")
+      end
+
+      it "returns display name for known language code 'de'" do
+        expect(dn.of("de")).to eq("ドイツ語")
+      end
+
+      it "returns code for unknown code with fallback: :code" do
+        expect(dn.of("xyz")).to eq("xyz")
+      end
+    end
+
+    context "with type: :language and fallback: :none" do
+      let(:dn) { ICU4X::DisplayNames.new(ICU4X::Locale.parse("ja"), provider:, type: :language, fallback: :none) }
+
+      it "returns nil for unknown code" do
+        expect(dn.of("xyz")).to be_nil
+      end
+    end
+
+    context "with type: :region" do
+      let(:dn) { ICU4X::DisplayNames.new(ICU4X::Locale.parse("ja"), provider:, type: :region) }
+
+      it "returns display name for known region code 'US'" do
+        expect(dn.of("US")).to eq("アメリカ合衆国")
+      end
+
+      it "returns display name for known region code 'JP'" do
+        expect(dn.of("JP")).to eq("日本")
+      end
+
+      it "returns display name for known region code 'GB'" do
+        expect(dn.of("GB")).to eq("イギリス")
+      end
+    end
+
+    context "with type: :script" do
+      let(:dn) { ICU4X::DisplayNames.new(ICU4X::Locale.parse("ja"), provider:, type: :script) }
+
+      it "returns display name for known script code 'Latn'" do
+        expect(dn.of("Latn")).to eq("ラテン文字")
+      end
+
+      it "returns display name for known script code 'Hant'" do
+        expect(dn.of("Hant")).to eq("繁体字")
+      end
+
+      it "returns display name for known script code 'Cyrl'" do
+        expect(dn.of("Cyrl")).to eq("キリル文字")
+      end
+    end
+
+    context "with type: :locale" do
+      let(:dn) { ICU4X::DisplayNames.new(ICU4X::Locale.parse("ja"), provider:, type: :locale) }
+
+      it "returns display name for full locale string 'en-US'" do
+        expect(dn.of("en-US")).to eq("アメリカ英語")
+      end
+
+      it "returns display name for locale with script 'zh-Hant'" do
+        expect(dn.of("zh-Hant")).to eq("標準中国語 (繁体字)")
+      end
+
+      it "returns display name for locale 'pt-BR'" do
+        expect(dn.of("pt-BR")).to eq("ポルトガル語 (ブラジル)")
+      end
+    end
+
+    context "with English locale" do
+      let(:dn) { ICU4X::DisplayNames.new(ICU4X::Locale.parse("en"), provider:, type: :language) }
+
+      it "returns English display name for 'ja'" do
+        expect(dn.of("ja")).to eq("Japanese")
+      end
+
+      it "returns English display name for 'en'" do
+        expect(dn.of("en")).to eq("English")
+      end
+    end
+  end
+
+  describe "#resolved_options" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    it "returns hash with locale, type, style, fallback (defaults)" do
+      dn = ICU4X::DisplayNames.new(ICU4X::Locale.parse("ja"), provider:, type: :language)
+
+      expect(dn.resolved_options).to eq({
+        locale: "ja",
+        type: :language,
+        style: :long,
+        fallback: :code
+      })
+    end
+
+    it "returns hash with custom options" do
+      dn = ICU4X::DisplayNames.new(
+        ICU4X::Locale.parse("en"),
+        provider:,
+        type: :region,
+        style: :short,
+        fallback: :none
+      )
+
+      expect(dn.resolved_options).to eq({
+        locale: "en",
+        type: :region,
+        style: :short,
+        fallback: :none
+      })
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Implement DisplayNames class for locale-aware display names of languages, regions, scripts, and locales. Equivalent to JavaScript's Intl.DisplayNames.

## Changes
- Add `ICU4X::DisplayNames` class with support for type: :language, :region, :script, :locale
- Implement style options (:long, :short, :narrow) and fallback behavior (:code, :none)
- Add RBS type definitions and documentation

## Test Plan
- Run `bundle exec rake` to verify all 258 tests pass
- Test display names: `ICU4X::DisplayNames.new(locale, provider:, type: :language).of("en")`

Closes #4
