### PR TITLE
:sparkles: Implement Segmenter class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,12 @@ inherit_gem:
 inherit_from: .rubocop_todo.yml
 
 # Project-specific settings
+
+# Native extension classes appear static from Ruby side but have methods defined in Rust
+Style/StaticClass:
+  Exclude:
+    - lib/icu4x.rb
+
 RSpec/SpecFilePathFormat:
   CustomTransform:
     ICU4X: icu4x

--- a/ext/icu4x/src/lib.rs
+++ b/ext/icu4x/src/lib.rs
@@ -7,6 +7,7 @@ mod list_format;
 mod locale;
 mod number_format;
 mod plural_rules;
+mod segmenter;
 
 use magnus::{Error, Ruby};
 
@@ -23,6 +24,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     list_format::init(ruby, &module)?;
     collator::init(ruby, &module)?;
     display_names::init(ruby, &module)?;
+    segmenter::init(ruby, &module)?;
 
     Ok(())
 }

--- a/ext/icu4x/src/segmenter.rs
+++ b/ext/icu4x/src/segmenter.rs
@@ -1,0 +1,363 @@
+use crate::data_provider::DataProvider;
+use icu::segmenter::options::{LineBreakOptions, SentenceBreakOptions, WordBreakOptions};
+use icu::segmenter::{
+    GraphemeClusterSegmenter, GraphemeClusterSegmenterBorrowed, LineSegmenter,
+    LineSegmenterBorrowed, SentenceSegmenter, SentenceSegmenterBorrowed, WordSegmenter,
+    WordSegmenterBorrowed,
+};
+use icu_provider::buf::AsDeserializingBufferProvider;
+use magnus::{
+    Error, ExceptionClass, RArray, RClass, RHash, RModule, Ruby, Symbol, TryConvert, Value,
+    function, method, prelude::*,
+};
+
+/// Granularity level for segmentation
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Granularity {
+    Grapheme,
+    Word,
+    Sentence,
+    Line,
+}
+
+impl Granularity {
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            Granularity::Grapheme => "grapheme",
+            Granularity::Word => "word",
+            Granularity::Sentence => "sentence",
+            Granularity::Line => "line",
+        }
+    }
+}
+
+/// Internal segmenter variants - using owned types
+enum SegmenterKind {
+    GraphemeBorrowed(GraphemeClusterSegmenterBorrowed<'static>),
+    GraphemeOwned(GraphemeClusterSegmenter),
+    WordBorrowed(WordSegmenterBorrowed<'static>),
+    WordOwned(WordSegmenter),
+    SentenceOwned(SentenceSegmenter),
+    LineOwned(LineSegmenter),
+}
+
+/// Ruby wrapper for ICU4X Segmenter
+#[magnus::wrap(class = "ICU4X::Segmenter", free_immediately, size)]
+pub struct Segmenter {
+    inner: SegmenterKind,
+    granularity: Granularity,
+}
+
+// SAFETY: Ruby's GVL protects access to this type.
+unsafe impl Send for Segmenter {}
+
+impl Segmenter {
+    /// Create a new Segmenter instance
+    ///
+    /// # Arguments
+    /// * `granularity:` - :grapheme, :word, :sentence, or :line
+    /// * `provider:` - A DataProvider instance (optional for :grapheme)
+    fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
+        // Parse arguments: (**kwargs)
+        let kwargs: RHash = if !args.is_empty() {
+            TryConvert::try_convert(args[0])?
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "missing keyword: :granularity",
+            ));
+        };
+
+        // Extract granularity (required)
+        let granularity_value: Symbol = kwargs
+            .lookup::<_, Option<Symbol>>(ruby.to_symbol("granularity"))?
+            .ok_or_else(|| {
+                Error::new(ruby.exception_arg_error(), "missing keyword: :granularity")
+            })?;
+
+        let grapheme_sym = ruby.to_symbol("grapheme");
+        let word_sym = ruby.to_symbol("word");
+        let sentence_sym = ruby.to_symbol("sentence");
+        let line_sym = ruby.to_symbol("line");
+
+        let granularity = if granularity_value.equal(grapheme_sym)? {
+            Granularity::Grapheme
+        } else if granularity_value.equal(word_sym)? {
+            Granularity::Word
+        } else if granularity_value.equal(sentence_sym)? {
+            Granularity::Sentence
+        } else if granularity_value.equal(line_sym)? {
+            Granularity::Line
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "granularity must be :grapheme, :word, :sentence, or :line",
+            ));
+        };
+
+        // Extract provider (optional for grapheme, recommended for others)
+        let provider_value: Option<Value> =
+            kwargs.lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?;
+
+        // Get the error exception class
+        let error_class: ExceptionClass = ruby
+            .eval("ICU4X::Error")
+            .unwrap_or_else(|_| ruby.exception_runtime_error());
+
+        // Create the appropriate segmenter
+        let inner = match granularity {
+            Granularity::Grapheme => {
+                if let Some(pv) = provider_value {
+                    let dp: &DataProvider = TryConvert::try_convert(pv).map_err(|_| {
+                        Error::new(
+                            ruby.exception_type_error(),
+                            "provider must be a DataProvider",
+                        )
+                    })?;
+                    let segmenter =
+                        GraphemeClusterSegmenter::try_new_unstable(&dp.inner.as_deserializing())
+                            .map_err(|e| {
+                                Error::new(
+                                    error_class,
+                                    format!("Failed to create Segmenter: {}", e),
+                                )
+                            })?;
+                    SegmenterKind::GraphemeOwned(segmenter)
+                } else {
+                    let segmenter = GraphemeClusterSegmenter::new();
+                    SegmenterKind::GraphemeBorrowed(segmenter)
+                }
+            }
+            Granularity::Word => {
+                let options = WordBreakOptions::default();
+                if let Some(pv) = provider_value {
+                    let dp: &DataProvider = TryConvert::try_convert(pv).map_err(|_| {
+                        Error::new(
+                            ruby.exception_type_error(),
+                            "provider must be a DataProvider",
+                        )
+                    })?;
+                    let segmenter =
+                        WordSegmenter::try_new_auto_unstable(&dp.inner.as_deserializing(), options)
+                            .map_err(|e| {
+                                Error::new(
+                                    error_class,
+                                    format!("Failed to create Segmenter: {}", e),
+                                )
+                            })?;
+                    SegmenterKind::WordOwned(segmenter)
+                } else {
+                    let segmenter = WordSegmenter::new_auto(Default::default());
+                    SegmenterKind::WordBorrowed(segmenter)
+                }
+            }
+            Granularity::Sentence => {
+                let options = SentenceBreakOptions::default();
+                let dp: &DataProvider = provider_value
+                    .ok_or_else(|| {
+                        Error::new(
+                            ruby.exception_arg_error(),
+                            "provider is required for sentence segmentation",
+                        )
+                    })
+                    .and_then(|v| {
+                        TryConvert::try_convert(v).map_err(|_| {
+                            Error::new(
+                                ruby.exception_type_error(),
+                                "provider must be a DataProvider",
+                            )
+                        })
+                    })?;
+
+                let segmenter =
+                    SentenceSegmenter::try_new_unstable(&dp.inner.as_deserializing(), options)
+                        .map_err(|e| {
+                            Error::new(error_class, format!("Failed to create Segmenter: {}", e))
+                        })?;
+                SegmenterKind::SentenceOwned(segmenter)
+            }
+            Granularity::Line => {
+                let options = LineBreakOptions::default();
+                let dp: &DataProvider = provider_value
+                    .ok_or_else(|| {
+                        Error::new(
+                            ruby.exception_arg_error(),
+                            "provider is required for line segmentation",
+                        )
+                    })
+                    .and_then(|v| {
+                        TryConvert::try_convert(v).map_err(|_| {
+                            Error::new(
+                                ruby.exception_type_error(),
+                                "provider must be a DataProvider",
+                            )
+                        })
+                    })?;
+
+                let segmenter =
+                    LineSegmenter::try_new_auto_unstable(&dp.inner.as_deserializing(), options)
+                        .map_err(|e| {
+                            Error::new(error_class, format!("Failed to create Segmenter: {}", e))
+                        })?;
+                SegmenterKind::LineOwned(segmenter)
+            }
+        };
+
+        Ok(Self { inner, granularity })
+    }
+
+    /// Segment text into units
+    ///
+    /// # Arguments
+    /// * `text` - Text to segment
+    ///
+    /// # Returns
+    /// Array of Segment objects
+    fn segment(&self, text: Value) -> Result<RArray, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+
+        let text_str: String = TryConvert::try_convert(text)
+            .map_err(|_| Error::new(ruby.exception_type_error(), "text must be a String"))?;
+
+        // Get the Segment class
+        let segment_class: RClass = ruby.eval("ICU4X::Segmenter::Segment")?;
+        let result = ruby.ary_new();
+
+        match &self.inner {
+            SegmenterKind::GraphemeBorrowed(segmenter) => {
+                self.segment_grapheme(segmenter, &text_str, &segment_class, &result)?;
+            }
+            SegmenterKind::GraphemeOwned(segmenter) => {
+                let borrowed = segmenter.as_borrowed();
+                self.segment_grapheme(&borrowed, &text_str, &segment_class, &result)?;
+            }
+            SegmenterKind::WordBorrowed(segmenter) => {
+                self.segment_word(segmenter, &text_str, &segment_class, &result)?;
+            }
+            SegmenterKind::WordOwned(segmenter) => {
+                let borrowed = segmenter.as_borrowed();
+                self.segment_word(&borrowed, &text_str, &segment_class, &result)?;
+            }
+            SegmenterKind::SentenceOwned(segmenter) => {
+                let borrowed = segmenter.as_borrowed();
+                self.segment_sentence(&borrowed, &text_str, &segment_class, &result)?;
+            }
+            SegmenterKind::LineOwned(segmenter) => {
+                let borrowed = segmenter.as_borrowed();
+                self.segment_line(&borrowed, &text_str, &segment_class, &result)?;
+            }
+        }
+
+        Ok(result)
+    }
+
+    fn segment_grapheme(
+        &self,
+        segmenter: &GraphemeClusterSegmenterBorrowed<'_>,
+        text_str: &str,
+        segment_class: &RClass,
+        result: &RArray,
+    ) -> Result<(), Error> {
+        let mut prev_index = 0;
+        for break_index in segmenter.segment_str(text_str) {
+            if break_index > prev_index {
+                let segment_str = &text_str[prev_index..break_index];
+                let segment = segment_class.funcall::<_, _, Value>(
+                    "new",
+                    (segment_str, prev_index, Option::<bool>::None),
+                )?;
+                result.push(segment)?;
+            }
+            prev_index = break_index;
+        }
+        Ok(())
+    }
+
+    fn segment_word(
+        &self,
+        segmenter: &WordSegmenterBorrowed<'_>,
+        text_str: &str,
+        segment_class: &RClass,
+        result: &RArray,
+    ) -> Result<(), Error> {
+        let mut prev_index = 0;
+        let iter = segmenter.segment_str(text_str);
+        for (break_index, word_type) in iter.iter_with_word_type() {
+            if break_index > prev_index {
+                let segment_str = &text_str[prev_index..break_index];
+                let is_word_like = word_type.is_word_like();
+                let segment = segment_class
+                    .funcall::<_, _, Value>("new", (segment_str, prev_index, Some(is_word_like)))?;
+                result.push(segment)?;
+            }
+            prev_index = break_index;
+        }
+        Ok(())
+    }
+
+    fn segment_sentence(
+        &self,
+        segmenter: &SentenceSegmenterBorrowed<'_>,
+        text_str: &str,
+        segment_class: &RClass,
+        result: &RArray,
+    ) -> Result<(), Error> {
+        let mut prev_index = 0;
+        for break_index in segmenter.segment_str(text_str) {
+            if break_index > prev_index {
+                let segment_str = &text_str[prev_index..break_index];
+                let segment = segment_class.funcall::<_, _, Value>(
+                    "new",
+                    (segment_str, prev_index, Option::<bool>::None),
+                )?;
+                result.push(segment)?;
+            }
+            prev_index = break_index;
+        }
+        Ok(())
+    }
+
+    fn segment_line(
+        &self,
+        segmenter: &LineSegmenterBorrowed<'_>,
+        text_str: &str,
+        segment_class: &RClass,
+        result: &RArray,
+    ) -> Result<(), Error> {
+        let mut prev_index = 0;
+        for break_index in segmenter.segment_str(text_str) {
+            if break_index > prev_index {
+                let segment_str = &text_str[prev_index..break_index];
+                let segment = segment_class.funcall::<_, _, Value>(
+                    "new",
+                    (segment_str, prev_index, Option::<bool>::None),
+                )?;
+                result.push(segment)?;
+            }
+            prev_index = break_index;
+        }
+        Ok(())
+    }
+
+    /// Get the resolved options
+    ///
+    /// # Returns
+    /// A hash with :granularity
+    fn resolved_options(&self) -> Result<RHash, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+        let hash = ruby.hash_new();
+        hash.aset(
+            ruby.to_symbol("granularity"),
+            ruby.to_symbol(self.granularity.to_symbol_name()),
+        )?;
+        Ok(hash)
+    }
+}
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("Segmenter", ruby.class_object())?;
+    class.define_singleton_method("new", function!(Segmenter::new, -1))?;
+    class.define_method("segment", method!(Segmenter::segment, 1))?;
+    class.define_method("resolved_options", method!(Segmenter::resolved_options, 0))?;
+    Ok(())
+}

--- a/lib/icu4x.rb
+++ b/lib/icu4x.rb
@@ -20,6 +20,32 @@ module ICU4X
   class DataGeneratorError < Error; end
 end
 
+# Define Segment data class for Segmenter
+module ICU4X
+  class Segmenter
+    Segment = Data.define(:segment, :index, :word_like)
+  end
+end
+
+# Enhance the Segment data class
+module ICU4X
+  class Segmenter
+    # Represents a segment of text.
+    #
+    # @!attribute [r] segment
+    #   @return [String] The segment string
+    # @!attribute [r] index
+    #   @return [Integer] Byte offset in original text
+    class Segment
+      # Whether this segment is word-like.
+      # @return [Boolean] true if word-like (letters, numbers, CJK ideographs)
+      # @return [nil] for non-word granularity
+      alias word_like? word_like
+      private :word_like
+    end
+  end
+end
+
 # Enhance the native Locale class
 module ICU4X
   # Represents a BCP 47 locale identifier.

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -161,4 +161,23 @@ module ICU4X
       fallback: display_names_fallback
     }
   end
+
+  type segmenter_granularity = :grapheme | :word | :sentence | :line
+
+  class Segmenter
+    class Segment
+      attr_reader segment: String
+      attr_reader index: Integer
+
+      def word_like?: () -> bool?
+    end
+
+    def self.new: (
+      granularity: segmenter_granularity,
+      ?provider: DataProvider
+    ) -> Segmenter
+
+    def segment: (String text) -> Array[Segment]
+    def resolved_options: () -> { granularity: segmenter_granularity }
+  end
 end

--- a/spec/icu4x/segmenter_spec.rb
+++ b/spec/icu4x/segmenter_spec.rb
@@ -1,0 +1,272 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+RSpec.describe ICU4X::Segmenter do
+  let(:fixtures_path) { Pathname.new(__dir__).parent / "fixtures" }
+  let(:valid_blob_path) { fixtures_path / "test-data.postcard" }
+
+  describe ".new" do
+    context "with granularity: :grapheme" do
+      it "creates without provider" do
+        segmenter = ICU4X::Segmenter.new(granularity: :grapheme)
+
+        expect(segmenter).to be_a(ICU4X::Segmenter)
+      end
+    end
+
+    context "with granularity: :word" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+      it "creates with provider" do
+        segmenter = ICU4X::Segmenter.new(granularity: :word, provider:)
+
+        expect(segmenter).to be_a(ICU4X::Segmenter)
+      end
+
+      it "creates without provider (uses built-in)" do
+        segmenter = ICU4X::Segmenter.new(granularity: :word)
+
+        expect(segmenter).to be_a(ICU4X::Segmenter)
+      end
+    end
+
+    context "with granularity: :sentence" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+      it "creates with provider" do
+        segmenter = ICU4X::Segmenter.new(granularity: :sentence, provider:)
+
+        expect(segmenter).to be_a(ICU4X::Segmenter)
+      end
+
+      it "raises ArgumentError without provider" do
+        expect { ICU4X::Segmenter.new(granularity: :sentence) }
+          .to raise_error(ArgumentError, /provider is required for sentence segmentation/)
+      end
+    end
+
+    context "with granularity: :line" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+      it "creates with provider" do
+        segmenter = ICU4X::Segmenter.new(granularity: :line, provider:)
+
+        expect(segmenter).to be_a(ICU4X::Segmenter)
+      end
+
+      it "raises ArgumentError without provider" do
+        expect { ICU4X::Segmenter.new(granularity: :line) }
+          .to raise_error(ArgumentError, /provider is required for line segmentation/)
+      end
+    end
+
+    context "with invalid arguments" do
+      it "raises ArgumentError when missing granularity keyword" do
+        expect { ICU4X::Segmenter.new }
+          .to raise_error(ArgumentError, /missing keyword: :granularity/)
+      end
+
+      it "raises ArgumentError for invalid granularity" do
+        expect { ICU4X::Segmenter.new(granularity: :invalid) }
+          .to raise_error(ArgumentError, /granularity must be :grapheme, :word, :sentence, or :line/)
+      end
+
+      it "raises TypeError when provider is invalid type" do
+        expect { ICU4X::Segmenter.new(granularity: :sentence, provider: "not a provider") }
+          .to raise_error(TypeError, /provider must be a DataProvider/)
+      end
+    end
+  end
+
+  describe "#segment" do
+    context "with granularity: :grapheme" do
+      let(:segmenter) { ICU4X::Segmenter.new(granularity: :grapheme) }
+
+      it "segments ASCII text" do
+        segments = segmenter.segment("abc")
+
+        expect(segments.map(&:segment)).to eq(%w[a b c])
+      end
+
+      it "segments combining characters" do
+        # café - the é is a single grapheme even if composed
+        segments = segmenter.segment("café")
+
+        expect(segments.map(&:segment)).to eq(%w[c a f é])
+      end
+
+      it "segments emoji with ZWJ" do
+        # Family emoji (👨‍👩‍👧) is a single grapheme
+        segments = segmenter.segment("👨‍👩‍👧")
+
+        expect(segments.size).to eq(1)
+        expect(segments.first.segment).to eq("👨‍👩‍👧")
+      end
+
+      it "segments Korean hangul" do
+        segments = segmenter.segment("한글")
+
+        expect(segments.map(&:segment)).to eq(%w[한 글])
+      end
+
+      it "returns correct byte indices" do
+        segments = segmenter.segment("abc")
+
+        expect(segments.map(&:index)).to eq([0, 1, 2])
+      end
+
+      it "returns nil for word_like?" do
+        segments = segmenter.segment("abc")
+
+        expect(segments.map(&:word_like?)).to all(be_nil)
+      end
+    end
+
+    context "with granularity: :word" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:segmenter) { ICU4X::Segmenter.new(granularity: :word, provider:) }
+
+      it "segments English words" do
+        segments = segmenter.segment("Hello, world!")
+
+        expect(segments.map(&:segment)).to eq(["Hello", ",", " ", "world", "!"])
+      end
+
+      it "identifies word-like segments" do
+        segments = segmenter.segment("Hello, world!")
+        word_like = segments.filter_map {|s| s.segment if s.word_like? }
+
+        expect(word_like).to eq(%w[Hello world])
+      end
+
+      it "identifies non-word-like segments" do
+        segments = segmenter.segment("Hello, world!")
+        non_word_like = segments.filter_map {|s| s.segment unless s.word_like? }
+
+        expect(non_word_like).to eq([",", " ", "!"])
+      end
+
+      it "segments Japanese text" do
+        segments = segmenter.segment("今日は良い天気です")
+        words = segments.filter_map {|s| s.segment if s.word_like? }
+
+        expect(words).to eq(%w[今日 は 良い 天気 です])
+      end
+
+      it "returns correct byte indices for multibyte text" do
+        # "こんにちは" (5 chars × 3 bytes = 15 bytes) + ", " (2 bytes) = 17 bytes before "world"
+        segments = segmenter.segment("こんにちは, world!")
+        # "world" should start at byte offset 17
+        world_segment = segments.find {|s| s.segment == "world" }
+
+        expect(world_segment.index).to eq(17)
+      end
+    end
+
+    context "with granularity: :sentence" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:segmenter) { ICU4X::Segmenter.new(granularity: :sentence, provider:) }
+
+      it "segments by sentence boundaries" do
+        segments = segmenter.segment("Hello there. How are you? I'm fine!")
+
+        expect(segments.map(&:segment)).to eq(["Hello there. ", "How are you? ", "I'm fine!"])
+      end
+
+      it "returns nil for word_like?" do
+        segments = segmenter.segment("Hello. World.")
+
+        expect(segments.map(&:word_like?)).to all(be_nil)
+      end
+    end
+
+    context "with granularity: :line" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:segmenter) { ICU4X::Segmenter.new(granularity: :line, provider:) }
+
+      it "identifies line break opportunities" do
+        segments = segmenter.segment("Hello world")
+
+        expect(segments.map(&:segment)).to eq(["Hello ", "world"])
+      end
+
+      it "returns nil for word_like?" do
+        segments = segmenter.segment("Hello world")
+
+        expect(segments.map(&:word_like?)).to all(be_nil)
+      end
+    end
+
+    it "raises TypeError for non-string input" do
+      segmenter = ICU4X::Segmenter.new(granularity: :grapheme)
+
+      expect { segmenter.segment(123) }
+        .to raise_error(TypeError, /text must be a String/)
+    end
+
+    it "returns empty array for empty string" do
+      segmenter = ICU4X::Segmenter.new(granularity: :grapheme)
+      segments = segmenter.segment("")
+
+      expect(segments).to eq([])
+    end
+  end
+
+  describe "#resolved_options" do
+    it "returns hash with granularity for grapheme" do
+      segmenter = ICU4X::Segmenter.new(granularity: :grapheme)
+
+      expect(segmenter.resolved_options).to eq({granularity: :grapheme})
+    end
+
+    it "returns hash with granularity for word" do
+      segmenter = ICU4X::Segmenter.new(granularity: :word)
+
+      expect(segmenter.resolved_options).to eq({granularity: :word})
+    end
+
+    it "returns hash with granularity for sentence" do
+      provider = ICU4X::DataProvider.from_blob(valid_blob_path)
+      segmenter = ICU4X::Segmenter.new(granularity: :sentence, provider:)
+
+      expect(segmenter.resolved_options).to eq({granularity: :sentence})
+    end
+
+    it "returns hash with granularity for line" do
+      provider = ICU4X::DataProvider.from_blob(valid_blob_path)
+      segmenter = ICU4X::Segmenter.new(granularity: :line, provider:)
+
+      expect(segmenter.resolved_options).to eq({granularity: :line})
+    end
+  end
+
+  describe ICU4X::Segmenter::Segment do
+    it "responds to #segment" do
+      segment = ICU4X::Segmenter::Segment.new(segment: "test", index: 0, word_like: nil)
+
+      expect(segment).to respond_to(:segment)
+      expect(segment.segment).to eq("test")
+    end
+
+    it "responds to #index" do
+      segment = ICU4X::Segmenter::Segment.new(segment: "test", index: 5, word_like: nil)
+
+      expect(segment).to respond_to(:index)
+      expect(segment.index).to eq(5)
+    end
+
+    it "responds to #word_like?" do
+      segment = ICU4X::Segmenter::Segment.new(segment: "test", index: 0, word_like: true)
+
+      expect(segment).to respond_to(:word_like?)
+      expect(segment.word_like?).to be(true)
+    end
+
+    it "allows nil for word_like?" do
+      segment = ICU4X::Segmenter::Segment.new(segment: "test", index: 0, word_like: nil)
+
+      expect(segment.word_like?).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add text segmentation support for grapheme clusters, words, sentences, and line breaks, equivalent to JavaScript's `Intl.Segmenter`.

## Changes
- Implement `ICU4X::Segmenter` class with four granularity levels (`:grapheme`, `:word`, `:sentence`, `:line`)
- Add `ICU4X::Segmenter::Segment` data class with `segment`, `index`, and `word_like?` attributes
- Exclude `Style/StaticClass` for native extension classes in RuboCop config

## Test Plan
```bash
bundle exec rspec spec/icu4x/segmenter_spec.rb
```

Closes #5
