### PR TITLE
:art: Fix Clippy warning in list_format.rs

### DIFF
--- a/ext/icu4x/src/list_format.rs
+++ b/ext/icu4x/src/list_format.rs
@@ -200,7 +200,7 @@ impl ListFormat {
 
         let items: Vec<String> = array
             .into_iter()
-            .map(|v| TryConvert::try_convert(v))
+            .map(TryConvert::try_convert)
             .collect::<Result<Vec<_>, _>>()?;
 
         let formatted = self.inner.format(items.iter().map(|s| s.as_str()));


### PR DESCRIPTION
## Summary
Fix Clippy warning in list_format.rs by replacing redundant closure with function reference.

## Changes
- Replace `.map(|v| TryConvert::try_convert(v))` with `.map(TryConvert::try_convert)`
