### PR TITLE
:construction: WIP: Implement DurationFormat class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ version = "0.1.0"
 dependencies = [
  "fixed_decimal",
  "icu",
+ "icu_experimental",
  "icu_locale",
  "icu_provider",
  "icu_provider_adapters",

--- a/doc/duration_format.md
+++ b/doc/duration_format.md
@@ -1,0 +1,155 @@
+# DurationFormat
+
+Locale-aware duration formatting. Equivalent to JavaScript's Intl.DurationFormat.
+
+---
+
+## Class Structure
+
+```
+ICU4X
+└─ DurationFormat
+```
+
+---
+
+## ICU4X::DurationFormat
+
+A class for formatting durations (time spans) in a locale-aware manner.
+
+### Interface
+
+```ruby
+module ICU4X
+  class DurationFormat
+    # Constructor
+    # @param locale [Locale] Locale
+    # @param provider [DataProvider] Data provider
+    # @param style [Symbol] :long (default), :short, :narrow, :digital
+    # @raise [ArgumentError] If style is invalid
+    # @raise [TypeError] If provider is not a DataProvider
+    # @raise [Error] If data loading fails
+    def initialize(locale, provider:, style: :long) = ...
+
+    # Format a duration
+    # @param duration [Hash] Duration components
+    # @option duration [Integer] :years
+    # @option duration [Integer] :months
+    # @option duration [Integer] :weeks
+    # @option duration [Integer] :days
+    # @option duration [Integer] :hours
+    # @option duration [Integer] :minutes
+    # @option duration [Integer] :seconds
+    # @option duration [Integer] :milliseconds
+    # @option duration [Integer] :microseconds
+    # @option duration [Integer] :nanoseconds
+    # @return [String]
+    # @raise [ArgumentError] If duration is empty or has negative values
+    def format(duration) = ...
+
+    # Get resolved options
+    # @return [Hash]
+    def resolved_options = ...
+  end
+end
+```
+
+---
+
+## style Option
+
+| Value | Description | Example (1h 30m in en) |
+|-------|-------------|------------------------|
+| `:long` | Full words (default) | "1 hour, 30 minutes" |
+| `:short` | Abbreviated | "1 hr, 30 min" |
+| `:narrow` | Minimal | "1h 30m" |
+| `:digital` | Digital clock format | "1:30:00" |
+
+---
+
+## duration Hash Keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `:years` | Integer | Number of years |
+| `:months` | Integer | Number of months |
+| `:weeks` | Integer | Number of weeks |
+| `:days` | Integer | Number of days |
+| `:hours` | Integer | Number of hours |
+| `:minutes` | Integer | Number of minutes |
+| `:seconds` | Integer | Number of seconds |
+| `:milliseconds` | Integer | Number of milliseconds |
+| `:microseconds` | Integer | Number of microseconds |
+| `:nanoseconds` | Integer | Number of nanoseconds |
+
+All keys are optional. At least one key with a non-zero value should be provided.
+
+---
+
+## Usage Examples
+
+### Basic Duration Formatting
+
+```ruby
+provider = ICU4X::DataProvider.from_blob(Pathname.new("data/i18n.blob"))
+locale = ICU4X::Locale.parse("en-US")
+
+df = ICU4X::DurationFormat.new(locale, provider: provider)
+
+df.format(hours: 1, minutes: 30)
+# => "1 hour, 30 minutes"
+
+df.format(days: 2, hours: 5, minutes: 15)
+# => "2 days, 5 hours, 15 minutes"
+```
+
+### Style Variations
+
+```ruby
+# Short style
+df_short = ICU4X::DurationFormat.new(locale, provider: provider, style: :short)
+df_short.format(hours: 2, minutes: 45)
+# => "2 hr, 45 min"
+
+# Narrow style
+df_narrow = ICU4X::DurationFormat.new(locale, provider: provider, style: :narrow)
+df_narrow.format(hours: 2, minutes: 45)
+# => "2h 45m"
+
+# Digital style
+df_digital = ICU4X::DurationFormat.new(locale, provider: provider, style: :digital)
+df_digital.format(hours: 1, minutes: 30, seconds: 45)
+# => "1:30:45"
+```
+
+### Japanese Locale
+
+```ruby
+locale_ja = ICU4X::Locale.parse("ja")
+df = ICU4X::DurationFormat.new(locale_ja, provider: provider)
+
+df.format(hours: 2, minutes: 15)
+# => "2時間15分"
+
+df.format(days: 3, hours: 12)
+# => "3日12時間"
+```
+
+### Fine-grained Time Units
+
+```ruby
+df.format(seconds: 5, milliseconds: 250)
+# => "5 seconds, 250 milliseconds"
+
+df.format(years: 1, months: 6)
+# => "1 year, 6 months"
+```
+
+---
+
+## Notes
+
+- All duration values must be non-negative integers
+- At least one duration component must be non-zero
+- The digital style (`1:30:45`) is primarily designed for hours, minutes, and seconds
+- Duration formatting follows locale-specific conventions for separators and unit names

--- a/ext/icu4x/Cargo.toml
+++ b/ext/icu4x/Cargo.toml
@@ -17,6 +17,7 @@ icu_provider_export = "2.1"
 icu_provider_registry = "2.1"
 icu_provider_adapters = "2.1"
 icu = { version = "2.1", features = ["experimental"] }
+icu_experimental = "0.4"
 fixed_decimal = "0.7"
 tinystr = "0.8"
 jiff = "0.2"

--- a/ext/icu4x/src/duration_format.rs
+++ b/ext/icu4x/src/duration_format.rs
@@ -1,0 +1,254 @@
+use crate::data_provider::DataProvider;
+use crate::locale::Locale;
+use icu::experimental::duration::options::{BaseStyle, DurationFormatterOptions};
+use icu::experimental::duration::{
+    Duration, DurationFormatter, DurationFormatterPreferences,
+};
+use icu_experimental::duration::formatter::ValidatedDurationFormatterOptions;
+use icu_provider::buf::AsDeserializingBufferProvider;
+use magnus::{
+    Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
+    prelude::*,
+};
+
+/// The style of duration formatting
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Style {
+    Long,
+    Short,
+    Narrow,
+    Digital,
+}
+
+impl Style {
+    fn to_base_style(self) -> BaseStyle {
+        match self {
+            Style::Long => BaseStyle::Long,
+            Style::Short => BaseStyle::Short,
+            Style::Narrow => BaseStyle::Narrow,
+            Style::Digital => BaseStyle::Digital,
+        }
+    }
+
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            Style::Long => "long",
+            Style::Short => "short",
+            Style::Narrow => "narrow",
+            Style::Digital => "digital",
+        }
+    }
+}
+
+/// Ruby wrapper for ICU4X DurationFormatter
+#[magnus::wrap(class = "ICU4X::DurationFormat", free_immediately, size)]
+pub struct DurationFormat {
+    inner: DurationFormatter,
+    locale_str: String,
+    style: Style,
+}
+
+// SAFETY: Ruby's GVL protects access to this type.
+unsafe impl Send for DurationFormat {}
+
+impl DurationFormat {
+    /// Create a new DurationFormat instance
+    ///
+    /// # Arguments
+    /// * `locale` - A Locale instance
+    /// * `provider:` - A DataProvider instance
+    /// * `style:` - :long (default), :short, :narrow, or :digital
+    fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
+        // Parse arguments: (locale, **kwargs)
+        if args.is_empty() {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "wrong number of arguments (given 0, expected 1+)",
+            ));
+        }
+
+        // Get the locale
+        let locale: &Locale = TryConvert::try_convert(args[0])?;
+        let locale_ref = locale.inner.borrow();
+        let locale_str = locale_ref.to_string();
+        let icu_locale = locale_ref.clone();
+        drop(locale_ref);
+
+        // Get kwargs
+        let kwargs: RHash = if args.len() > 1 {
+            TryConvert::try_convert(args[1])?
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "missing keyword: :provider",
+            ));
+        };
+
+        // Extract provider (required)
+        let provider_value: Value = kwargs
+            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
+            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+
+        // Extract style option (default: :long)
+        let style_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("style"))?;
+        let long_sym = ruby.to_symbol("long");
+        let short_sym = ruby.to_symbol("short");
+        let narrow_sym = ruby.to_symbol("narrow");
+        let digital_sym = ruby.to_symbol("digital");
+        let style_sym = style_value.unwrap_or(long_sym);
+
+        let style = if style_sym.equal(long_sym)? {
+            Style::Long
+        } else if style_sym.equal(short_sym)? {
+            Style::Short
+        } else if style_sym.equal(narrow_sym)? {
+            Style::Narrow
+        } else if style_sym.equal(digital_sym)? {
+            Style::Digital
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "style must be :long, :short, :narrow, or :digital",
+            ));
+        };
+
+        // Get the error exception class
+        let error_class: ExceptionClass = ruby
+            .eval("ICU4X::Error")
+            .unwrap_or_else(|_| ruby.exception_runtime_error());
+
+        // Get the DataProvider
+        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+            Error::new(
+                ruby.exception_type_error(),
+                "provider must be a DataProvider",
+            )
+        })?;
+
+        // Build formatter options
+        let mut options = DurationFormatterOptions::default();
+        options.base = style.to_base_style();
+        let validated_options = ValidatedDurationFormatterOptions::validate(options).map_err(|e| {
+            Error::new(
+                error_class,
+                format!("Invalid DurationFormat options: {:?}", e),
+            )
+        })?;
+
+        // Create formatter
+        let prefs: DurationFormatterPreferences = (&icu_locale).into();
+        let formatter =
+            DurationFormatter::try_new_unstable(&dp.inner.as_deserializing(), prefs, validated_options)
+                .map_err(|e| {
+                    Error::new(
+                        error_class,
+                        format!("Failed to create DurationFormat: {}", e),
+                    )
+                })?;
+
+        Ok(Self {
+            inner: formatter,
+            locale_str,
+            style,
+        })
+    }
+
+    /// Format a duration
+    ///
+    /// # Arguments
+    /// * `duration` - A Hash with duration components
+    ///
+    /// # Returns
+    /// A formatted string
+    fn format(&self, duration_hash: RHash) -> Result<String, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+
+        // Extract duration components from hash
+        let years = Self::extract_u64(&ruby, &duration_hash, "years")?;
+        let months = Self::extract_u64(&ruby, &duration_hash, "months")?;
+        let weeks = Self::extract_u64(&ruby, &duration_hash, "weeks")?;
+        let days = Self::extract_u64(&ruby, &duration_hash, "days")?;
+        let hours = Self::extract_u64(&ruby, &duration_hash, "hours")?;
+        let minutes = Self::extract_u64(&ruby, &duration_hash, "minutes")?;
+        let seconds = Self::extract_u64(&ruby, &duration_hash, "seconds")?;
+        let milliseconds = Self::extract_u64(&ruby, &duration_hash, "milliseconds")?;
+        let microseconds = Self::extract_u64(&ruby, &duration_hash, "microseconds")?;
+        let nanoseconds = Self::extract_u64(&ruby, &duration_hash, "nanoseconds")?;
+
+        // Check that at least one component is provided
+        if years == 0
+            && months == 0
+            && weeks == 0
+            && days == 0
+            && hours == 0
+            && minutes == 0
+            && seconds == 0
+            && milliseconds == 0
+            && microseconds == 0
+            && nanoseconds == 0
+        {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "duration must have at least one non-zero component",
+            ));
+        }
+
+        // Create Duration
+        let duration = Duration {
+            years,
+            months,
+            weeks,
+            days,
+            hours,
+            minutes,
+            seconds,
+            milliseconds,
+            microseconds,
+            nanoseconds,
+            ..Default::default()
+        };
+
+        let formatted = self.inner.format(&duration);
+        Ok(formatted.to_string())
+    }
+
+    /// Extract a u64 value from hash
+    fn extract_u64(ruby: &Ruby, hash: &RHash, key: &str) -> Result<u64, Error> {
+        let value: Option<i64> = hash.lookup::<_, Option<i64>>(ruby.to_symbol(key))?;
+        match value {
+            Some(v) if v < 0 => Err(Error::new(
+                ruby.exception_arg_error(),
+                format!("{} must be non-negative", key),
+            )),
+            Some(v) => Ok(v as u64),
+            None => Ok(0),
+        }
+    }
+
+    /// Get the resolved options
+    ///
+    /// # Returns
+    /// A hash with :locale and :style keys
+    fn resolved_options(&self) -> Result<RHash, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+        let hash = ruby.hash_new();
+        hash.aset(ruby.to_symbol("locale"), self.locale_str.as_str())?;
+        hash.aset(
+            ruby.to_symbol("style"),
+            ruby.to_symbol(self.style.to_symbol_name()),
+        )?;
+        Ok(hash)
+    }
+}
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("DurationFormat", ruby.class_object())?;
+    class.define_singleton_method("new", function!(DurationFormat::new, -1))?;
+    class.define_method("format", method!(DurationFormat::format, 1))?;
+    class.define_method(
+        "resolved_options",
+        method!(DurationFormat::resolved_options, 0),
+    )?;
+    Ok(())
+}

--- a/ext/icu4x/src/lib.rs
+++ b/ext/icu4x/src/lib.rs
@@ -3,6 +3,7 @@ mod data_generator;
 mod data_provider;
 mod datetime_format;
 mod display_names;
+mod duration_format;
 mod list_format;
 mod locale;
 mod number_format;
@@ -21,6 +22,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     plural_rules::init(ruby, &module)?;
     number_format::init(ruby, &module)?;
     datetime_format::init(ruby, &module)?;
+    duration_format::init(ruby, &module)?;
     list_format::init(ruby, &module)?;
     collator::init(ruby, &module)?;
     display_names::init(ruby, &module)?;

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -53,6 +53,7 @@ module ICU4X
 
   type date_style = :full | :long | :medium | :short
   type time_style = :full | :long | :medium | :short
+  type duration_format_style = :long | :short | :narrow | :digital
 
   class NumberFormat
     def self.new: (
@@ -97,6 +98,33 @@ module ICU4X
       ?date_style: date_style,
       ?time_style: time_style,
       ?time_zone: String
+    }
+  end
+
+  type duration_components = {
+    ?years: Integer,
+    ?months: Integer,
+    ?weeks: Integer,
+    ?days: Integer,
+    ?hours: Integer,
+    ?minutes: Integer,
+    ?seconds: Integer,
+    ?milliseconds: Integer,
+    ?microseconds: Integer,
+    ?nanoseconds: Integer
+  }
+
+  class DurationFormat
+    def self.new: (
+      Locale locale,
+      provider: DataProvider,
+      ?style: duration_format_style
+    ) -> DurationFormat
+
+    def format: (duration_components duration) -> String
+    def resolved_options: () -> {
+      locale: String,
+      style: duration_format_style
     }
   end
 

--- a/spec/icu4x/duration_format_spec.rb
+++ b/spec/icu4x/duration_format_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+RSpec.describe ICU4X::DurationFormat do
+  let(:fixtures_path) { Pathname.new(__dir__).parent / "fixtures" }
+  let(:valid_blob_path) { fixtures_path / "test-data.postcard" }
+
+  describe ".new" do
+    context "with DataProvider" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "creates with default options" do
+        df = ICU4X::DurationFormat.new(locale, provider:)
+
+        expect(df).to be_a(ICU4X::DurationFormat)
+      end
+
+      it "creates with style: :long" do
+        df = ICU4X::DurationFormat.new(locale, provider:, style: :long)
+
+        expect(df).to be_a(ICU4X::DurationFormat)
+      end
+
+      it "creates with style: :short" do
+        df = ICU4X::DurationFormat.new(locale, provider:, style: :short)
+
+        expect(df).to be_a(ICU4X::DurationFormat)
+      end
+
+      it "creates with style: :narrow" do
+        df = ICU4X::DurationFormat.new(locale, provider:, style: :narrow)
+
+        expect(df).to be_a(ICU4X::DurationFormat)
+      end
+
+      it "creates with style: :digital" do
+        df = ICU4X::DurationFormat.new(locale, provider:, style: :digital)
+
+        expect(df).to be_a(ICU4X::DurationFormat)
+      end
+    end
+
+    context "with invalid arguments" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "raises ArgumentError when missing provider keyword" do
+        expect { ICU4X::DurationFormat.new(locale) }
+          .to raise_error(ArgumentError, /missing keyword: :provider/)
+      end
+
+      it "raises ArgumentError for invalid style" do
+        expect { ICU4X::DurationFormat.new(locale, provider:, style: :invalid) }
+          .to raise_error(ArgumentError, /style must be :long, :short, :narrow, or :digital/)
+      end
+
+      it "raises TypeError when provider is invalid type" do
+        expect { ICU4X::DurationFormat.new(locale, provider: "not a provider") }
+          .to raise_error(TypeError, /provider must be a DataProvider/)
+      end
+    end
+  end
+
+  describe "#format" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    context "with style: :long (default)" do
+      let(:df) { ICU4X::DurationFormat.new(ICU4X::Locale.parse("en"), provider:) }
+
+      it "formats hours and minutes" do
+        result = df.format(hours: 1, minutes: 30)
+
+        expect(result).to include("1")
+        expect(result).to include("hour")
+        expect(result).to include("30")
+        expect(result).to include("minute")
+      end
+
+      it "formats days, hours, and minutes" do
+        result = df.format(days: 2, hours: 5, minutes: 15)
+
+        expect(result).to include("2")
+        expect(result).to include("day")
+        expect(result).to include("5")
+        expect(result).to include("hour")
+        expect(result).to include("15")
+        expect(result).to include("minute")
+      end
+
+      it "formats single unit" do
+        result = df.format(seconds: 45)
+
+        expect(result).to include("45")
+        expect(result).to include("second")
+      end
+
+      it "formats years and months" do
+        result = df.format(years: 1, months: 6)
+
+        expect(result).to include("1")
+        expect(result).to include("year")
+        expect(result).to include("6")
+        expect(result).to include("month")
+      end
+
+      it "formats weeks" do
+        result = df.format(weeks: 3)
+
+        expect(result).to include("3")
+        expect(result).to include("week")
+      end
+
+      it "formats milliseconds" do
+        result = df.format(milliseconds: 500)
+
+        expect(result).to include("500")
+        expect(result).to include("millisecond")
+      end
+    end
+
+    context "with style: :short" do
+      let(:df) { ICU4X::DurationFormat.new(ICU4X::Locale.parse("en"), provider:, style: :short) }
+
+      it "uses abbreviated units" do
+        result = df.format(hours: 2, minutes: 45)
+
+        expect(result).to include("2")
+        expect(result).to include("45")
+      end
+    end
+
+    context "with style: :narrow" do
+      let(:df) { ICU4X::DurationFormat.new(ICU4X::Locale.parse("en"), provider:, style: :narrow) }
+
+      it "uses minimal format" do
+        result = df.format(hours: 2, minutes: 45)
+
+        expect(result).to include("2")
+        expect(result).to include("45")
+      end
+    end
+
+    context "with style: :digital" do
+      let(:df) { ICU4X::DurationFormat.new(ICU4X::Locale.parse("en"), provider:, style: :digital) }
+
+      it "formats as digital clock" do
+        result = df.format(hours: 1, minutes: 30, seconds: 45)
+
+        expect(result).to match(/1.*30.*45/)
+      end
+    end
+
+    context "with Japanese locale" do
+      let(:df) { ICU4X::DurationFormat.new(ICU4X::Locale.parse("ja"), provider:) }
+
+      it "formats in Japanese" do
+        result = df.format(hours: 2, minutes: 15)
+
+        expect(result).to include("2")
+        expect(result).to include("15")
+      end
+    end
+
+    context "with invalid input" do
+      let(:df) { ICU4X::DurationFormat.new(ICU4X::Locale.parse("en"), provider:) }
+
+      it "raises ArgumentError for empty duration" do
+        expect { df.format({}) }
+          .to raise_error(ArgumentError, /duration must have at least one non-zero component/)
+      end
+
+      it "raises ArgumentError for all-zero duration" do
+        expect { df.format(hours: 0, minutes: 0) }
+          .to raise_error(ArgumentError, /duration must have at least one non-zero component/)
+      end
+
+      it "raises ArgumentError for negative values" do
+        expect { df.format(hours: -1) }
+          .to raise_error(ArgumentError, /hours must be non-negative/)
+      end
+    end
+  end
+
+  describe "#resolved_options" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    it "returns hash with locale and style for defaults" do
+      df = ICU4X::DurationFormat.new(ICU4X::Locale.parse("en"), provider:)
+
+      expect(df.resolved_options).to eq({locale: "en", style: :long})
+    end
+
+    it "returns hash with specified style" do
+      df = ICU4X::DurationFormat.new(
+        ICU4X::Locale.parse("ja"),
+        provider:,
+        style: :short
+      )
+
+      expect(df.resolved_options).to eq({locale: "ja", style: :short})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
WIP implementation of DurationFormat class for locale-aware duration formatting (equivalent to JavaScript's Intl.DurationFormat).

**⚠️ BLOCKED**: Implementation cannot compile due to ICU4X API issue.

## Issue
`ValidatedDurationFormatterOptions` is not publicly exported from `icu_experimental` crate, yet all `DurationFormatter` constructors require it.

### Details
- Type defined in `validated_options.rs` with `pub(crate)` visibility
- All constructors (`try_new`, `try_new_unstable`, `try_new_with_buffer_provider`) require `ValidatedDurationFormatterOptions`
- No public method to convert `DurationFormatterOptions` to `ValidatedDurationFormatterOptions`

## Completed Work
- Rust implementation (`ext/icu4x/src/duration_format.rs`)
- Module registration in `lib.rs`
- RBS type definitions (`sig/icu4x.rbs`)
- RSpec test suite (`spec/icu4x/duration_format_spec.rb`)
- User documentation (`doc/duration_format.md`)

## Next Steps
1. File issue with ICU4X about missing public export
2. Wait for fix or newer ICU4X version
3. Resume implementation once `ValidatedDurationFormatterOptions` is publicly exported

## References
- [GSoC 2024 DurationFormat Implementation](https://gist.github.com/kartva/ff139f31876a42a0934ef84755596b2e)
- [icu_experimental 0.4.0 documentation](https://docs.rs/icu_experimental/0.4.0/icu_experimental/duration/)

Closes #6 (when unblocked)
