### PR TITLE
:sparkles: Implement RelativeTimeFormat class

### DIFF
--- a/doc/relative_time_format.md
+++ b/doc/relative_time_format.md
@@ -1,0 +1,173 @@
+# RelativeTimeFormat
+
+Locale-aware relative time formatting. Equivalent to JavaScript's Intl.RelativeTimeFormat.
+
+---
+
+## Class Structure
+
+```
+ICU4X
+└─ RelativeTimeFormat
+```
+
+---
+
+## ICU4X::RelativeTimeFormat
+
+A class for formatting relative time expressions (e.g., "3 days ago", "in 2 hours").
+
+### Interface
+
+```ruby
+module ICU4X
+  class RelativeTimeFormat
+    # Constructor
+    # @param locale [Locale] Locale
+    # @param provider [DataProvider] Data provider
+    # @param style [Symbol] :long (default), :short, :narrow
+    # @param numeric [Symbol] :always (default), :auto
+    # @raise [ArgumentError] If style or numeric is invalid
+    # @raise [Error] If data loading fails
+    def initialize(locale, provider:, style: :long, numeric: :always) = ...
+
+    # Format relative time
+    # @param value [Integer] The relative time value (negative = past, positive = future)
+    # @param unit [Symbol] :second, :minute, :hour, :day, :week, :month, :quarter, :year
+    # @return [String]
+    # @raise [ArgumentError] If unit is invalid
+    def format(value, unit) = ...
+
+    # Get resolved options
+    # @return [Hash]
+    def resolved_options = ...
+  end
+end
+```
+
+---
+
+## style Option
+
+| Value | Description | Example (-3, :day in en) |
+|-------|-------------|--------------------------|
+| `:long` | Full words (default) | "3 days ago" |
+| `:short` | Abbreviated | "3 days ago" |
+| `:narrow` | Minimal | "3d ago" |
+
+---
+
+## numeric Option
+
+| Value | Description | Example (-1, :day in en) |
+|-------|-------------|--------------------------|
+| `:always` | Always use numbers (default) | "1 day ago" |
+| `:auto` | Use words when available | "yesterday" |
+
+---
+
+## unit Option
+
+| Value | Description |
+|-------|-------------|
+| `:second` | Seconds |
+| `:minute` | Minutes |
+| `:hour` | Hours |
+| `:day` | Days |
+| `:week` | Weeks |
+| `:month` | Months |
+| `:quarter` | Quarters |
+| `:year` | Years |
+
+---
+
+## Usage Examples
+
+### Basic Relative Time
+
+```ruby
+provider = ICU4X::DataProvider.from_blob(Pathname.new("data/i18n.blob"))
+locale = ICU4X::Locale.parse("en-US")
+
+rtf = ICU4X::RelativeTimeFormat.new(locale, provider: provider)
+
+# Past
+rtf.format(-3, :day)    # => "3 days ago"
+rtf.format(-1, :hour)   # => "1 hour ago"
+rtf.format(-2, :week)   # => "2 weeks ago"
+
+# Future
+rtf.format(2, :day)     # => "in 2 days"
+rtf.format(1, :month)   # => "in 1 month"
+rtf.format(5, :minute)  # => "in 5 minutes"
+```
+
+### Numeric vs Auto
+
+```ruby
+# numeric: :always (default)
+rtf = ICU4X::RelativeTimeFormat.new(locale, provider: provider)
+rtf.format(-1, :day)   # => "1 day ago"
+rtf.format(0, :day)    # => "in 0 days"
+rtf.format(1, :day)    # => "in 1 day"
+
+# numeric: :auto
+rtf_auto = ICU4X::RelativeTimeFormat.new(locale, provider: provider, numeric: :auto)
+rtf_auto.format(-1, :day)   # => "yesterday"
+rtf_auto.format(0, :day)    # => "today"
+rtf_auto.format(1, :day)    # => "tomorrow"
+rtf_auto.format(-2, :day)   # => "2 days ago" (no special word for -2)
+```
+
+### Style Variations
+
+```ruby
+# Short style
+rtf_short = ICU4X::RelativeTimeFormat.new(locale, provider: provider, style: :short)
+rtf_short.format(-3, :hour)  # => "3 hr. ago"
+
+# Narrow style
+rtf_narrow = ICU4X::RelativeTimeFormat.new(locale, provider: provider, style: :narrow)
+rtf_narrow.format(-3, :hour)  # => "3h ago"
+```
+
+### Japanese Locale
+
+```ruby
+locale_ja = ICU4X::Locale.parse("ja")
+rtf = ICU4X::RelativeTimeFormat.new(locale_ja, provider: provider)
+
+rtf.format(-3, :day)    # => "3 日前"
+rtf.format(1, :week)    # => "1 週間後"
+rtf.format(-2, :month)  # => "2 か月前"
+
+# With numeric: :auto
+rtf_auto = ICU4X::RelativeTimeFormat.new(locale_ja, provider: provider, numeric: :auto)
+rtf_auto.format(-1, :day)  # => "昨日"
+rtf_auto.format(1, :day)   # => "明日"
+```
+
+### All Time Units
+
+```ruby
+rtf = ICU4X::RelativeTimeFormat.new(locale, provider: provider)
+
+rtf.format(-30, :second)   # => "30 seconds ago"
+rtf.format(15, :minute)    # => "in 15 minutes"
+rtf.format(-2, :hour)      # => "2 hours ago"
+rtf.format(3, :day)        # => "in 3 days"
+rtf.format(-1, :week)      # => "1 week ago"
+rtf.format(6, :month)      # => "in 6 months"
+rtf.format(-2, :quarter)   # => "2 quarters ago"
+rtf.format(1, :year)       # => "in 1 year"
+```
+
+---
+
+## Notes
+
+- Negative values represent past time ("X ago")
+- Positive values represent future time ("in X")
+- Zero is treated as future ("in 0 days")
+- The `numeric: :auto` option uses special words like "yesterday", "today", "tomorrow" when available
+- Relative time patterns vary by locale (e.g., Japanese uses "前" for past and "後" for future)

--- a/ext/icu4x/src/lib.rs
+++ b/ext/icu4x/src/lib.rs
@@ -7,6 +7,7 @@ mod list_format;
 mod locale;
 mod number_format;
 mod plural_rules;
+mod relative_time_format;
 mod segmenter;
 
 use magnus::{Error, Ruby};
@@ -25,6 +26,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     collator::init(ruby, &module)?;
     display_names::init(ruby, &module)?;
     segmenter::init(ruby, &module)?;
+    relative_time_format::init(ruby, &module)?;
 
     Ok(())
 }

--- a/ext/icu4x/src/relative_time_format.rs
+++ b/ext/icu4x/src/relative_time_format.rs
@@ -1,0 +1,359 @@
+use crate::data_provider::DataProvider;
+use crate::locale::Locale;
+use fixed_decimal::Decimal;
+use icu::experimental::relativetime::options::Numeric;
+use icu::experimental::relativetime::{
+    RelativeTimeFormatter, RelativeTimeFormatterOptions, RelativeTimeFormatterPreferences,
+};
+use icu_provider::buf::AsDeserializingBufferProvider;
+use magnus::{
+    Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
+    prelude::*,
+};
+
+/// The style of relative time formatting
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Style {
+    Long,
+    Short,
+    Narrow,
+}
+
+impl Style {
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            Style::Long => "long",
+            Style::Short => "short",
+            Style::Narrow => "narrow",
+        }
+    }
+}
+
+/// The numeric mode for relative time formatting
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NumericMode {
+    Always,
+    Auto,
+}
+
+impl NumericMode {
+    fn to_icu_numeric(self) -> Numeric {
+        match self {
+            NumericMode::Always => Numeric::Always,
+            NumericMode::Auto => Numeric::Auto,
+        }
+    }
+
+    fn to_symbol_name(self) -> &'static str {
+        match self {
+            NumericMode::Always => "always",
+            NumericMode::Auto => "auto",
+        }
+    }
+}
+
+/// Time unit for relative time formatting
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum Unit {
+    Second,
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Month,
+    Quarter,
+    Year,
+}
+
+impl Unit {
+    fn from_symbol(ruby: &Ruby, sym: Symbol) -> Result<Self, Error> {
+        let second_sym = ruby.to_symbol("second");
+        let minute_sym = ruby.to_symbol("minute");
+        let hour_sym = ruby.to_symbol("hour");
+        let day_sym = ruby.to_symbol("day");
+        let week_sym = ruby.to_symbol("week");
+        let month_sym = ruby.to_symbol("month");
+        let quarter_sym = ruby.to_symbol("quarter");
+        let year_sym = ruby.to_symbol("year");
+
+        if sym.equal(second_sym)? {
+            Ok(Unit::Second)
+        } else if sym.equal(minute_sym)? {
+            Ok(Unit::Minute)
+        } else if sym.equal(hour_sym)? {
+            Ok(Unit::Hour)
+        } else if sym.equal(day_sym)? {
+            Ok(Unit::Day)
+        } else if sym.equal(week_sym)? {
+            Ok(Unit::Week)
+        } else if sym.equal(month_sym)? {
+            Ok(Unit::Month)
+        } else if sym.equal(quarter_sym)? {
+            Ok(Unit::Quarter)
+        } else if sym.equal(year_sym)? {
+            Ok(Unit::Year)
+        } else {
+            Err(Error::new(
+                ruby.exception_arg_error(),
+                "unit must be :second, :minute, :hour, :day, :week, :month, :quarter, or :year",
+            ))
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Unit::Second => 0,
+            Unit::Minute => 1,
+            Unit::Hour => 2,
+            Unit::Day => 3,
+            Unit::Week => 4,
+            Unit::Month => 5,
+            Unit::Quarter => 6,
+            Unit::Year => 7,
+        }
+    }
+}
+
+/// Ruby wrapper for ICU4X RelativeTimeFormatter
+///
+/// Stores formatters for all 8 time units for the selected style.
+#[magnus::wrap(class = "ICU4X::RelativeTimeFormat", free_immediately, size)]
+pub struct RelativeTimeFormat {
+    formatters: [RelativeTimeFormatter; 8],
+    locale_str: String,
+    style: Style,
+    numeric: NumericMode,
+}
+
+// SAFETY: Ruby's GVL protects access to this type.
+unsafe impl Send for RelativeTimeFormat {}
+
+impl RelativeTimeFormat {
+    /// Create a new RelativeTimeFormat instance
+    ///
+    /// # Arguments
+    /// * `locale` - A Locale instance
+    /// * `provider:` - A DataProvider instance
+    /// * `style:` - :long (default), :short, :narrow
+    /// * `numeric:` - :always (default), :auto
+    fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
+        // Parse arguments: (locale, **kwargs)
+        if args.is_empty() {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "wrong number of arguments (given 0, expected 1+)",
+            ));
+        }
+
+        // Get the locale
+        let locale: &Locale = TryConvert::try_convert(args[0])?;
+        let locale_ref = locale.inner.borrow();
+        let locale_str = locale_ref.to_string();
+        let icu_locale = locale_ref.clone();
+        drop(locale_ref);
+
+        // Get kwargs
+        let kwargs: RHash = if args.len() > 1 {
+            TryConvert::try_convert(args[1])?
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "missing keyword: :provider",
+            ));
+        };
+
+        // Extract provider (required)
+        let provider_value: Value = kwargs
+            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
+            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+
+        // Extract style option (default: :long)
+        let style_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("style"))?;
+        let long_sym = ruby.to_symbol("long");
+        let short_sym = ruby.to_symbol("short");
+        let narrow_sym = ruby.to_symbol("narrow");
+        let style_sym = style_value.unwrap_or(long_sym);
+
+        let style = if style_sym.equal(long_sym)? {
+            Style::Long
+        } else if style_sym.equal(short_sym)? {
+            Style::Short
+        } else if style_sym.equal(narrow_sym)? {
+            Style::Narrow
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "style must be :long, :short, or :narrow",
+            ));
+        };
+
+        // Extract numeric option (default: :always)
+        let numeric_value: Option<Symbol> =
+            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("numeric"))?;
+        let always_sym = ruby.to_symbol("always");
+        let auto_sym = ruby.to_symbol("auto");
+        let numeric_sym = numeric_value.unwrap_or(always_sym);
+
+        let numeric = if numeric_sym.equal(always_sym)? {
+            NumericMode::Always
+        } else if numeric_sym.equal(auto_sym)? {
+            NumericMode::Auto
+        } else {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                "numeric must be :always or :auto",
+            ));
+        };
+
+        // Get the error exception class
+        let error_class: ExceptionClass = ruby
+            .eval("ICU4X::Error")
+            .unwrap_or_else(|_| ruby.exception_runtime_error());
+
+        // Get the DataProvider
+        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+            Error::new(
+                ruby.exception_type_error(),
+                "provider must be a DataProvider",
+            )
+        })?;
+
+        // Build formatter options
+        let options = RelativeTimeFormatterOptions {
+            numeric: numeric.to_icu_numeric(),
+        };
+        let prefs: RelativeTimeFormatterPreferences = (&icu_locale).into();
+
+        // Create formatters for all units based on style
+        let formatters = Self::create_formatters(dp, prefs, options, style, error_class)?;
+
+        Ok(Self {
+            formatters,
+            locale_str,
+            style,
+            numeric,
+        })
+    }
+
+    /// Create formatters for all 8 units
+    fn create_formatters(
+        dp: &DataProvider,
+        prefs: RelativeTimeFormatterPreferences,
+        options: RelativeTimeFormatterOptions,
+        style: Style,
+        error_class: ExceptionClass,
+    ) -> Result<[RelativeTimeFormatter; 8], Error> {
+        let provider = &dp.inner.as_deserializing();
+
+        macro_rules! create_formatter {
+            ($long:ident, $short:ident, $narrow:ident) => {
+                match style {
+                    Style::Long => RelativeTimeFormatter::$long(provider, prefs, options),
+                    Style::Short => RelativeTimeFormatter::$short(provider, prefs, options),
+                    Style::Narrow => RelativeTimeFormatter::$narrow(provider, prefs, options),
+                }
+                .map_err(|e| {
+                    Error::new(
+                        error_class,
+                        format!("Failed to create RelativeTimeFormat: {}", e),
+                    )
+                })
+            };
+        }
+
+        let second = create_formatter!(
+            try_new_long_second_unstable,
+            try_new_short_second_unstable,
+            try_new_narrow_second_unstable
+        )?;
+        let minute = create_formatter!(
+            try_new_long_minute_unstable,
+            try_new_short_minute_unstable,
+            try_new_narrow_minute_unstable
+        )?;
+        let hour = create_formatter!(
+            try_new_long_hour_unstable,
+            try_new_short_hour_unstable,
+            try_new_narrow_hour_unstable
+        )?;
+        let day = create_formatter!(
+            try_new_long_day_unstable,
+            try_new_short_day_unstable,
+            try_new_narrow_day_unstable
+        )?;
+        let week = create_formatter!(
+            try_new_long_week_unstable,
+            try_new_short_week_unstable,
+            try_new_narrow_week_unstable
+        )?;
+        let month = create_formatter!(
+            try_new_long_month_unstable,
+            try_new_short_month_unstable,
+            try_new_narrow_month_unstable
+        )?;
+        let quarter = create_formatter!(
+            try_new_long_quarter_unstable,
+            try_new_short_quarter_unstable,
+            try_new_narrow_quarter_unstable
+        )?;
+        let year = create_formatter!(
+            try_new_long_year_unstable,
+            try_new_short_year_unstable,
+            try_new_narrow_year_unstable
+        )?;
+
+        Ok([second, minute, hour, day, week, month, quarter, year])
+    }
+
+    /// Format a relative time value
+    ///
+    /// # Arguments
+    /// * `value` - The relative time value (negative = past, positive = future)
+    /// * `unit` - The time unit (:second, :minute, :hour, :day, :week, :month, :quarter, :year)
+    ///
+    /// # Returns
+    /// A formatted string
+    fn format(&self, value: i64, unit: Symbol) -> Result<String, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+
+        let unit = Unit::from_symbol(&ruby, unit)?;
+        let formatter = &self.formatters[unit.index()];
+
+        // Convert i64 to Decimal
+        let decimal = Decimal::from(value);
+
+        let formatted = formatter.format(decimal);
+        Ok(formatted.to_string())
+    }
+
+    /// Get the resolved options
+    ///
+    /// # Returns
+    /// A hash with :locale, :style, and :numeric keys
+    fn resolved_options(&self) -> Result<RHash, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+        let hash = ruby.hash_new();
+        hash.aset(ruby.to_symbol("locale"), self.locale_str.as_str())?;
+        hash.aset(
+            ruby.to_symbol("style"),
+            ruby.to_symbol(self.style.to_symbol_name()),
+        )?;
+        hash.aset(
+            ruby.to_symbol("numeric"),
+            ruby.to_symbol(self.numeric.to_symbol_name()),
+        )?;
+        Ok(hash)
+    }
+}
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("RelativeTimeFormat", ruby.class_object())?;
+    class.define_singleton_method("new", function!(RelativeTimeFormat::new, -1))?;
+    class.define_method("format", method!(RelativeTimeFormat::format, 2))?;
+    class.define_method(
+        "resolved_options",
+        method!(RelativeTimeFormat::resolved_options, 0),
+    )?;
+    Ok(())
+}

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -100,6 +100,26 @@ module ICU4X
     }
   end
 
+  type relative_time_format_style = :long | :short | :narrow
+  type relative_time_format_numeric = :always | :auto
+  type relative_time_unit = :second | :minute | :hour | :day | :week | :month | :quarter | :year
+
+  class RelativeTimeFormat
+    def self.new: (
+      Locale locale,
+      provider: DataProvider,
+      ?style: relative_time_format_style,
+      ?numeric: relative_time_format_numeric
+    ) -> RelativeTimeFormat
+
+    def format: (Integer value, relative_time_unit unit) -> String
+    def resolved_options: () -> {
+      locale: String,
+      style: relative_time_format_style,
+      numeric: relative_time_format_numeric
+    }
+  end
+
   type list_format_type = :conjunction | :disjunction | :unit
   type list_format_style = :long | :short | :narrow
 

--- a/spec/icu4x/relative_time_format_spec.rb
+++ b/spec/icu4x/relative_time_format_spec.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+RSpec.describe ICU4X::RelativeTimeFormat do
+  let(:fixtures_path) { Pathname.new(__dir__).parent / "fixtures" }
+  let(:valid_blob_path) { fixtures_path / "test-data.postcard" }
+
+  describe ".new" do
+    context "with DataProvider" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "creates with default options" do
+        rtf = ICU4X::RelativeTimeFormat.new(locale, provider:)
+
+        expect(rtf).to be_a(ICU4X::RelativeTimeFormat)
+      end
+
+      it "creates with style: :long" do
+        rtf = ICU4X::RelativeTimeFormat.new(locale, provider:, style: :long)
+
+        expect(rtf).to be_a(ICU4X::RelativeTimeFormat)
+      end
+
+      it "creates with style: :short" do
+        rtf = ICU4X::RelativeTimeFormat.new(locale, provider:, style: :short)
+
+        expect(rtf).to be_a(ICU4X::RelativeTimeFormat)
+      end
+
+      it "creates with style: :narrow" do
+        rtf = ICU4X::RelativeTimeFormat.new(locale, provider:, style: :narrow)
+
+        expect(rtf).to be_a(ICU4X::RelativeTimeFormat)
+      end
+
+      it "creates with numeric: :always" do
+        rtf = ICU4X::RelativeTimeFormat.new(locale, provider:, numeric: :always)
+
+        expect(rtf).to be_a(ICU4X::RelativeTimeFormat)
+      end
+
+      it "creates with numeric: :auto" do
+        rtf = ICU4X::RelativeTimeFormat.new(locale, provider:, numeric: :auto)
+
+        expect(rtf).to be_a(ICU4X::RelativeTimeFormat)
+      end
+    end
+
+    context "with invalid arguments" do
+      let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      it "raises ArgumentError when missing provider keyword" do
+        expect { ICU4X::RelativeTimeFormat.new(locale) }
+          .to raise_error(ArgumentError, /missing keyword: :provider/)
+      end
+
+      it "raises ArgumentError for invalid style" do
+        expect { ICU4X::RelativeTimeFormat.new(locale, provider:, style: :invalid) }
+          .to raise_error(ArgumentError, /style must be :long, :short, or :narrow/)
+      end
+
+      it "raises ArgumentError for invalid numeric" do
+        expect { ICU4X::RelativeTimeFormat.new(locale, provider:, numeric: :invalid) }
+          .to raise_error(ArgumentError, /numeric must be :always or :auto/)
+      end
+
+      it "raises TypeError when provider is invalid type" do
+        expect { ICU4X::RelativeTimeFormat.new(locale, provider: "not a provider") }
+          .to raise_error(TypeError, /provider must be a DataProvider/)
+      end
+    end
+  end
+
+  describe "#format" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    context "with default options (style: :long, numeric: :always)" do
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(ICU4X::Locale.parse("en"), provider:) }
+
+      it "formats past time with days" do
+        result = rtf.format(-3, :day)
+
+        expect(result).to eq("3 days ago")
+      end
+
+      it "formats future time with days" do
+        result = rtf.format(2, :day)
+
+        expect(result).to eq("in 2 days")
+      end
+
+      it "formats past time with hours" do
+        result = rtf.format(-1, :hour)
+
+        expect(result).to eq("1 hour ago")
+      end
+
+      it "formats future time with minutes" do
+        result = rtf.format(5, :minute)
+
+        expect(result).to eq("in 5 minutes")
+      end
+
+      it "formats past time with weeks" do
+        result = rtf.format(-2, :week)
+
+        expect(result).to eq("2 weeks ago")
+      end
+
+      it "formats future time with months" do
+        result = rtf.format(1, :month)
+
+        expect(result).to eq("in 1 month")
+      end
+
+      it "formats zero days" do
+        result = rtf.format(0, :day)
+
+        expect(result).to eq("in 0 days")
+      end
+    end
+
+    context "with numeric: :auto" do
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(ICU4X::Locale.parse("en"), provider:, numeric: :auto) }
+
+      it "uses 'yesterday' for -1 day" do
+        result = rtf.format(-1, :day)
+
+        expect(result).to eq("yesterday")
+      end
+
+      it "uses 'today' for 0 days" do
+        result = rtf.format(0, :day)
+
+        expect(result).to eq("today")
+      end
+
+      it "uses 'tomorrow' for 1 day" do
+        result = rtf.format(1, :day)
+
+        expect(result).to eq("tomorrow")
+      end
+
+      it "falls back to numeric for -2 days" do
+        result = rtf.format(-2, :day)
+
+        expect(result).to eq("2 days ago")
+      end
+    end
+
+    context "with different units" do
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(ICU4X::Locale.parse("en"), provider:) }
+
+      it "formats seconds" do
+        result = rtf.format(-30, :second)
+
+        expect(result).to eq("30 seconds ago")
+      end
+
+      it "formats minutes" do
+        result = rtf.format(15, :minute)
+
+        expect(result).to eq("in 15 minutes")
+      end
+
+      it "formats hours" do
+        result = rtf.format(-2, :hour)
+
+        expect(result).to eq("2 hours ago")
+      end
+
+      it "formats days" do
+        result = rtf.format(3, :day)
+
+        expect(result).to eq("in 3 days")
+      end
+
+      it "formats weeks" do
+        result = rtf.format(-1, :week)
+
+        expect(result).to eq("1 week ago")
+      end
+
+      it "formats months" do
+        result = rtf.format(6, :month)
+
+        expect(result).to eq("in 6 months")
+      end
+
+      it "formats quarters" do
+        result = rtf.format(-2, :quarter)
+
+        expect(result).to eq("2 quarters ago")
+      end
+
+      it "formats years" do
+        result = rtf.format(1, :year)
+
+        expect(result).to eq("in 1 year")
+      end
+    end
+
+    context "with style: :short" do
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(ICU4X::Locale.parse("en"), provider:, style: :short) }
+
+      it "uses abbreviated format" do
+        result = rtf.format(-3, :hour)
+
+        expect(result).to include("3")
+        expect(result).to include("ago")
+      end
+    end
+
+    context "with style: :narrow" do
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(ICU4X::Locale.parse("en"), provider:, style: :narrow) }
+
+      it "uses minimal format" do
+        result = rtf.format(-3, :hour)
+
+        expect(result).to include("3")
+      end
+    end
+
+    context "with Japanese locale" do
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(ICU4X::Locale.parse("ja"), provider:) }
+
+      it "formats past time in Japanese" do
+        result = rtf.format(-3, :day)
+
+        expect(result).to include("3")
+      end
+
+      it "formats future time in Japanese" do
+        result = rtf.format(1, :week)
+
+        expect(result).to include("1")
+      end
+    end
+
+    context "with invalid unit" do
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(ICU4X::Locale.parse("en"), provider:) }
+
+      it "raises ArgumentError for invalid unit" do
+        expect { rtf.format(-1, :invalid) }
+          .to raise_error(ArgumentError, /unit must be :second, :minute, :hour, :day, :week, :month, :quarter, or :year/)
+      end
+    end
+  end
+
+  describe "#resolved_options" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    it "returns hash with locale, style, numeric for defaults" do
+      rtf = ICU4X::RelativeTimeFormat.new(ICU4X::Locale.parse("en"), provider:)
+
+      expect(rtf.resolved_options).to eq({locale: "en", style: :long, numeric: :always})
+    end
+
+    it "returns hash with specified style and numeric" do
+      rtf = ICU4X::RelativeTimeFormat.new(
+        ICU4X::Locale.parse("ja"),
+        provider:,
+        style: :short,
+        numeric: :auto
+      )
+
+      expect(rtf.resolved_options).to eq({locale: "ja", style: :short, numeric: :auto})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Implement locale-aware relative time formatting equivalent to JavaScript's Intl.RelativeTimeFormat.

## Changes
- Add `RelativeTimeFormat` class with format method
- Support all 8 time units: second, minute, hour, day, week, month, quarter, year
- Style options: `:long`, `:short`, `:narrow`
- Numeric modes: `:always` (default) and `:auto` (for "yesterday", "tomorrow" etc.)

## Test Plan
- Run `bundle exec rspec spec/icu4x/relative_time_format_spec.rb`
- 36 test examples covering all units, styles, and edge cases

Closes #7
