### PR TITLE
:sparkles: Add calendar support to DateTimeFormat

### DIFF
--- a/doc/datetime_format.md
+++ b/doc/datetime_format.md
@@ -28,9 +28,9 @@ module ICU4X
     # @param date_style [Symbol, nil] :full, :long, :medium, :short
     # @param time_style [Symbol, nil] :full, :long, :medium, :short
     # @param time_zone [String, nil] IANA timezone name (e.g., "Asia/Tokyo")
-    # @param calendar [Symbol] :gregory (only gregory is currently supported)
+    # @param calendar [Symbol] :gregory, :japanese, :buddhist, :chinese, :hebrew, :islamic, :persian, :indian, :ethiopian, :coptic, :roc, :dangi
     # @raise [Error] If options are invalid
-    def initialize(locale, provider:, date_style: nil, time_style: nil, time_zone: nil, calendar: :gregory) = ...
+    def initialize(locale, provider:, date_style: nil, time_style: nil, time_zone: nil, calendar: nil) = ...
 
     # Format a time
     # @param time [Time] Time to format
@@ -74,7 +74,24 @@ dtf = ICU4X::DateTimeFormat.new(
 
 #### calendar
 
-Currently only `:gregory` (Gregorian calendar) is supported. Specifying other values raises an error.
+Specify the calendar system to use for formatting.
+
+| Value | Description |
+|-------|-------------|
+| `:gregory` | Gregorian calendar (default) |
+| `:japanese` | Japanese Imperial calendar (Reiwa, Heisei, etc.) |
+| `:buddhist` | Buddhist calendar (Thai Buddhist Era) |
+| `:chinese` | Traditional Chinese calendar |
+| `:hebrew` | Hebrew calendar |
+| `:islamic` | Islamic (Hijri) calendar |
+| `:persian` | Persian (Solar Hijri) calendar |
+| `:indian` | Indian National calendar |
+| `:ethiopian` | Ethiopian calendar |
+| `:coptic` | Coptic calendar |
+| `:roc` | Republic of China (Minguo) calendar |
+| `:dangi` | Korean traditional calendar |
+
+If not specified, defaults based on locale preferences.
 
 ---
 
@@ -113,13 +130,47 @@ dtf.format(Time.utc(2025, 12, 28, 0, 0))
 # => "2025年12月28日 9:00"
 ```
 
+### Calendar Examples
+
+```ruby
+# Japanese calendar (Reiwa era)
+dtf = ICU4X::DateTimeFormat.new(
+  locale,
+  provider: provider,
+  date_style: :long,
+  calendar: :japanese
+)
+dtf.format(Time.utc(2025, 12, 28))
+# => "December 28, 7 Reiwa" (in en-US locale)
+
+# Buddhist calendar (BE 2568 = CE 2025)
+dtf = ICU4X::DateTimeFormat.new(
+  locale,
+  provider: provider,
+  date_style: :long,
+  calendar: :buddhist
+)
+dtf.format(Time.utc(2025, 12, 28))
+# => "December 28, 2568 BE"
+
+# ROC calendar (Minguo 114 = CE 2025)
+dtf = ICU4X::DateTimeFormat.new(
+  locale,
+  provider: provider,
+  date_style: :long,
+  calendar: :roc
+)
+dtf.format(Time.utc(2025, 12, 28))
+# => "December 28, 114 Minguo"
+```
+
 ### Resolved Options
 
 ```ruby
 dtf.resolved_options
 # => {
 #   locale: "ja-JP",
-#   calendar: :gregory,
+#   calendar: :japanese,
 #   date_style: :long,
 #   time_style: :short,
 #   time_zone: "Asia/Tokyo"
@@ -171,13 +222,20 @@ module ICU4X
 end
 ```
 
-### Additional Calendar Support
+---
 
-| Calendar | Status | Notes |
-|----------|--------|-------|
-| `:gregory` | Implemented | Gregorian calendar (default) |
-| `:japanese` | Not implemented | Japanese calendar (Reiwa, Heisei, etc.) |
-| Others | Not implemented | Buddhist, Hijri, etc. |
+## Known Limitations
 
-Adding calendars requires regenerating the DataProvider blob data.
+### CLDR Data Differences from Other Implementations
+
+ICU4X uses CLDR (Common Locale Data Repository) data, but the formatting output may differ from other implementations like JavaScript's `Intl.DateTimeFormat` (V8/Node.js).
+
+Example with Japanese locale and Chinese calendar:
+
+| Implementation | CLDR Version | Output |
+|----------------|--------------|--------|
+| Node.js (V8 ICU) | CLDR 47 | 乙巳年十一月一二日 (day in Chinese numerals) |
+| ICU4X 2.1.1 | CLDR 48 | 乙巳年十一月9日 (day in Arabic numerals) |
+
+The CLDR data specifies `_numbers: "hanidec"` for Chinese calendar date formats in Japanese locale, indicating that Han decimal numerals (一、二、三...) should be used. However, ICU4X does not apply this numbering system attribute, resulting in Arabic numerals for the day field. This is an ICU4X implementation difference, not a CLDR data issue. This is not controllable at the gem level.
 

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -53,6 +53,7 @@ module ICU4X
 
   type date_style = :full | :long | :medium | :short
   type time_style = :full | :long | :medium | :short
+  type datetime_calendar = :gregory | :japanese | :buddhist | :chinese | :hebrew | :islamic | :persian | :indian | :ethiopian | :coptic | :roc | :dangi
 
   class NumberFormat
     def self.new: (
@@ -87,13 +88,13 @@ module ICU4X
       ?date_style: date_style,
       ?time_style: time_style,
       ?time_zone: String,
-      ?calendar: Symbol
+      ?calendar: datetime_calendar
     ) -> DateTimeFormat
 
     def format: (Time time) -> String
     def resolved_options: () -> {
       locale: String,
-      calendar: Symbol,
+      calendar: datetime_calendar,
       ?date_style: date_style,
       ?time_style: time_style,
       ?time_zone: String

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe ICU4X::DateTimeFormat do
           .to raise_error(ArgumentError, /time_style must be :full, :long, :medium, or :short/)
       end
 
-      it "raises ArgumentError when calendar is not :gregory" do
-        expect { ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :japanese) }
-          .to raise_error(ArgumentError, /only :gregory calendar is currently supported/)
+      it "raises ArgumentError when calendar is invalid" do
+        expect { ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :invalid) }
+          .to raise_error(ArgumentError, /calendar must be/)
       end
 
       it "raises ArgumentError when time_zone is invalid" do
@@ -256,6 +256,140 @@ RSpec.describe ICU4X::DateTimeFormat do
       formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, time_zone: "Asia/Tokyo")
 
       expect(formatter.resolved_options).to include(time_zone: "Asia/Tokyo")
+    end
+
+    it "returns specified calendar" do
+      formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :japanese)
+
+      expect(formatter.resolved_options).to include(calendar: :japanese)
+    end
+  end
+
+  describe "calendar support" do
+    let(:locale) { ICU4X::Locale.parse("en-US") }
+    let(:test_time) { Time.utc(2025, 12, 28) }
+
+    context "with :japanese calendar" do
+      it "creates formatter with Japanese calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :japanese)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:japanese)
+      end
+
+      it "formats date in Japanese era" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :japanese)
+
+        result = formatter.format(test_time)
+
+        expect(result).to include("Reiwa")
+      end
+    end
+
+    context "with :buddhist calendar" do
+      it "creates formatter with Buddhist calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :buddhist)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:buddhist)
+      end
+
+      it "formats date in Buddhist era (BE 2568 for 2025 CE)" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :buddhist)
+
+        result = formatter.format(test_time)
+
+        expect(result).to include("2568")
+      end
+    end
+
+    context "with :hebrew calendar" do
+      it "creates formatter with Hebrew calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :hebrew)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:hebrew)
+      end
+    end
+
+    context "with :chinese calendar" do
+      it "creates formatter with Chinese calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :chinese)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:chinese)
+      end
+    end
+
+    context "with :coptic calendar" do
+      it "creates formatter with Coptic calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :coptic)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:coptic)
+      end
+    end
+
+    context "with :ethiopian calendar" do
+      it "creates formatter with Ethiopian calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :ethiopian)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:ethiopian)
+      end
+    end
+
+    context "with :indian calendar" do
+      it "creates formatter with Indian calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :indian)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:indian)
+      end
+    end
+
+    context "with :islamic calendar" do
+      it "creates formatter with Islamic calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :islamic)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:islamic)
+      end
+    end
+
+    context "with :persian calendar" do
+      it "creates formatter with Persian calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :persian)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:persian)
+      end
+    end
+
+    context "with :roc calendar" do
+      it "creates formatter with ROC calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :roc)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:roc)
+      end
+
+      it "formats date in ROC era (114 for 2025 CE)" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :roc)
+
+        result = formatter.format(test_time)
+
+        expect(result).to include("114")
+      end
+    end
+
+    context "with :dangi calendar" do
+      it "creates formatter with Dangi calendar" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :dangi)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        expect(formatter.resolved_options[:calendar]).to eq(:dangi)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Add support for multiple calendar systems to DateTimeFormat, enabling locale-aware date formatting with non-Gregorian calendars like Japanese, Buddhist, Chinese, Hebrew, and Islamic.

## Changes
- Add Calendar enum with 12 calendar types (gregory, japanese, buddhist, chinese, hebrew, islamic, persian, indian, ethiopian, coptic, roc, dangi)
- Update DateTimeFormat constructor to accept calendar option and set CalendarAlgorithm preference
- Return actual calendar from resolved_options based on formatter's calendar kind
- Document known limitation: ICU4X does not apply CLDR's `_numbers: "hanidec"` attribute for Chinese calendar formatting

## Test Plan
- Run `bundle exec rspec spec/icu4x/datetime_format_spec.rb`
- All 344 examples pass including new calendar support tests

Closes #8

:robot: Generated with [Claude Code](https://claude.com/claude-code)
