### PR TITLE
:sparkles: Make provider argument optional for all formatter classes

### DIFF
--- a/ext/icu4x/src/collator.rs
+++ b/ext/icu4x/src/collator.rs
@@ -92,20 +92,32 @@ impl Collator {
         let icu_locale = locale_ref.clone();
         drop(locale_ref);
 
-        // Get kwargs
+        // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {
             TryConvert::try_convert(args[1])?
         } else {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "missing keyword: :provider",
-            ));
+            ruby.hash_new()
         };
 
-        // Extract provider (required)
-        let provider_value: Value = kwargs
-            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
-            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+        // Extract provider (optional, falls back to default)
+        let provider_value: Option<Value> =
+            kwargs.lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?;
+
+        // Resolve provider: use explicit or fall back to default
+        let resolved_provider: Value = match provider_value {
+            Some(v) if !v.is_nil() => v,
+            _ => {
+                let icu4x_module: RModule = ruby.eval("ICU4X")?;
+                let default: Value = icu4x_module.funcall("default_provider", ())?;
+                if default.is_nil() {
+                    return Err(Error::new(
+                        ruby.exception_arg_error(),
+                        "No provider specified and no default configured. Set ICU4X_DATA_PATH environment variable or use ICU4X.configure.",
+                    ));
+                }
+                default
+            }
+        };
 
         // Extract sensitivity option (default: :variant)
         let sensitivity_value: Option<Symbol> =
@@ -163,7 +175,7 @@ impl Collator {
             .unwrap_or_else(|_| ruby.exception_runtime_error());
 
         // Get the DataProvider
-        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+        let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {
             Error::new(
                 ruby.exception_type_error(),
                 "provider must be a DataProvider",

--- a/ext/icu4x/src/display_names.rs
+++ b/ext/icu4x/src/display_names.rs
@@ -126,20 +126,32 @@ impl DisplayNames {
         let icu_locale = locale_ref.clone();
         drop(locale_ref);
 
-        // Get kwargs
+        // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {
             TryConvert::try_convert(args[1])?
         } else {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "missing keyword: :provider",
-            ));
+            ruby.hash_new()
         };
 
-        // Extract provider (required)
-        let provider_value: Value = kwargs
-            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
-            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+        // Extract provider (optional, falls back to default)
+        let provider_value: Option<Value> =
+            kwargs.lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?;
+
+        // Resolve provider: use explicit or fall back to default
+        let resolved_provider: Value = match provider_value {
+            Some(v) if !v.is_nil() => v,
+            _ => {
+                let icu4x_module: RModule = ruby.eval("ICU4X")?;
+                let default: Value = icu4x_module.funcall("default_provider", ())?;
+                if default.is_nil() {
+                    return Err(Error::new(
+                        ruby.exception_arg_error(),
+                        "No provider specified and no default configured. Set ICU4X_DATA_PATH environment variable or use ICU4X.configure.",
+                    ));
+                }
+                default
+            }
+        };
 
         // Extract type (required)
         let type_value: Option<Symbol> =
@@ -212,7 +224,7 @@ impl DisplayNames {
             .unwrap_or_else(|_| ruby.exception_runtime_error());
 
         // Get the DataProvider
-        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+        let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {
             Error::new(
                 ruby.exception_type_error(),
                 "provider must be a DataProvider",

--- a/ext/icu4x/src/list_format.rs
+++ b/ext/icu4x/src/list_format.rs
@@ -88,20 +88,32 @@ impl ListFormat {
         let icu_locale = locale_ref.clone();
         drop(locale_ref);
 
-        // Get kwargs
+        // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {
             TryConvert::try_convert(args[1])?
         } else {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "missing keyword: :provider",
-            ));
+            ruby.hash_new()
         };
 
-        // Extract provider (required)
-        let provider_value: Value = kwargs
-            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
-            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+        // Extract provider (optional, falls back to default)
+        let provider_value: Option<Value> =
+            kwargs.lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?;
+
+        // Resolve provider: use explicit or fall back to default
+        let resolved_provider: Value = match provider_value {
+            Some(v) if !v.is_nil() => v,
+            _ => {
+                let icu4x_module: RModule = ruby.eval("ICU4X")?;
+                let default: Value = icu4x_module.funcall("default_provider", ())?;
+                if default.is_nil() {
+                    return Err(Error::new(
+                        ruby.exception_arg_error(),
+                        "No provider specified and no default configured. Set ICU4X_DATA_PATH environment variable or use ICU4X.configure.",
+                    ));
+                }
+                default
+            }
+        };
 
         // Extract type option (default: :conjunction)
         let type_value: Option<Symbol> =
@@ -151,7 +163,7 @@ impl ListFormat {
             .unwrap_or_else(|_| ruby.exception_runtime_error());
 
         // Get the DataProvider
-        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+        let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {
             Error::new(
                 ruby.exception_type_error(),
                 "provider must be a DataProvider",

--- a/ext/icu4x/src/number_format.rs
+++ b/ext/icu4x/src/number_format.rs
@@ -125,20 +125,33 @@ impl NumberFormat {
         let icu_locale = locale_ref.clone();
         drop(locale_ref);
 
-        // Get kwargs
+        // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {
             TryConvert::try_convert(args[1])?
         } else {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "missing keyword: :provider",
-            ));
+            ruby.hash_new()
         };
 
-        // Extract provider (required)
-        let provider_value: Value = kwargs
-            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
-            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+        // Extract provider (optional, falls back to default)
+        let provider_value: Option<Value> =
+            kwargs.lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?;
+
+        // Resolve provider: use explicit or fall back to default
+        let resolved_provider: Value = match provider_value {
+            Some(v) if !v.is_nil() => v,
+            _ => {
+                // Call ICU4X.default_provider
+                let icu4x_module: RModule = ruby.eval("ICU4X")?;
+                let default: Value = icu4x_module.funcall("default_provider", ())?;
+                if default.is_nil() {
+                    return Err(Error::new(
+                        ruby.exception_arg_error(),
+                        "No provider specified and no default configured. Set ICU4X_DATA_PATH environment variable or use ICU4X.configure.",
+                    ));
+                }
+                default
+            }
+        };
 
         // Extract style option (default: :decimal)
         let style_value: Option<Symbol> =
@@ -194,7 +207,7 @@ impl NumberFormat {
             .unwrap_or_else(|_| ruby.exception_runtime_error());
 
         // Get the DataProvider
-        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+        let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {
             Error::new(
                 ruby.exception_type_error(),
                 "provider must be a DataProvider",

--- a/ext/icu4x/src/plural_rules.rs
+++ b/ext/icu4x/src/plural_rules.rs
@@ -48,20 +48,32 @@ impl PluralRules {
         // Convert to PluralRulesPreferences
         let prefs: PluralRulesPreferences = (&icu_locale).into();
 
-        // Get kwargs
+        // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {
             TryConvert::try_convert(args[1])?
         } else {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "missing keyword: :provider",
-            ));
+            ruby.hash_new()
         };
 
-        // Extract provider (required)
-        let provider_value: Value = kwargs
-            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
-            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+        // Extract provider (optional, falls back to default)
+        let provider_value: Option<Value> =
+            kwargs.lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?;
+
+        // Resolve provider: use explicit or fall back to default
+        let resolved_provider: Value = match provider_value {
+            Some(v) if !v.is_nil() => v,
+            _ => {
+                let icu4x_module: RModule = ruby.eval("ICU4X")?;
+                let default: Value = icu4x_module.funcall("default_provider", ())?;
+                if default.is_nil() {
+                    return Err(Error::new(
+                        ruby.exception_arg_error(),
+                        "No provider specified and no default configured. Set ICU4X_DATA_PATH environment variable or use ICU4X.configure.",
+                    ));
+                }
+                default
+            }
+        };
 
         // Extract type option (default: :cardinal)
         let type_value: Option<Symbol> =
@@ -87,7 +99,7 @@ impl PluralRules {
             .unwrap_or_else(|_| ruby.exception_runtime_error());
 
         // Get the DataProvider
-        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+        let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {
             Error::new(
                 ruby.exception_type_error(),
                 "provider must be a DataProvider",

--- a/ext/icu4x/src/relative_time_format.rs
+++ b/ext/icu4x/src/relative_time_format.rs
@@ -152,20 +152,32 @@ impl RelativeTimeFormat {
         let icu_locale = locale_ref.clone();
         drop(locale_ref);
 
-        // Get kwargs
+        // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {
             TryConvert::try_convert(args[1])?
         } else {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "missing keyword: :provider",
-            ));
+            ruby.hash_new()
         };
 
-        // Extract provider (required)
-        let provider_value: Value = kwargs
-            .lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?
-            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :provider"))?;
+        // Extract provider (optional, falls back to default)
+        let provider_value: Option<Value> =
+            kwargs.lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?;
+
+        // Resolve provider: use explicit or fall back to default
+        let resolved_provider: Value = match provider_value {
+            Some(v) if !v.is_nil() => v,
+            _ => {
+                let icu4x_module: RModule = ruby.eval("ICU4X")?;
+                let default: Value = icu4x_module.funcall("default_provider", ())?;
+                if default.is_nil() {
+                    return Err(Error::new(
+                        ruby.exception_arg_error(),
+                        "No provider specified and no default configured. Set ICU4X_DATA_PATH environment variable or use ICU4X.configure.",
+                    ));
+                }
+                default
+            }
+        };
 
         // Extract style option (default: :long)
         let style_value: Option<Symbol> =
@@ -212,7 +224,7 @@ impl RelativeTimeFormat {
             .unwrap_or_else(|_| ruby.exception_runtime_error());
 
         // Get the DataProvider
-        let dp: &DataProvider = TryConvert::try_convert(provider_value).map_err(|_| {
+        let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {
             Error::new(
                 ruby.exception_type_error(),
                 "provider must be a DataProvider",

--- a/icu4x.gemspec
+++ b/icu4x.gemspec
@@ -35,5 +35,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/icu4x/extconf.rb"]
 
+  spec.add_dependency "dry-configurable", "~> 1.3"
   spec.add_dependency "rb_sys", "~> 0.9"
 end

--- a/sig/dry-configurable.rbs
+++ b/sig/dry-configurable.rbs
@@ -1,0 +1,11 @@
+module Dry
+  module Configurable
+    interface _Config
+      def data_path: () -> Pathname?
+    end
+
+    def self?.setting: (Symbol name, ?default: untyped, ?constructor: ^(untyped) -> untyped) -> void
+    def self?.config: () -> _Config
+    def self?.configure: () { (_Config) -> void } -> void
+  end
+end

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -1,5 +1,10 @@
 module ICU4X
+  extend Dry::Configurable
+
   VERSION: String
+
+  def self.default_provider: () -> DataProvider?
+  def self.reset_default_provider!: () -> void
 
   class Error < StandardError
   end
@@ -41,7 +46,7 @@ module ICU4X
   type plural_rule_type = :cardinal | :ordinal
 
   class PluralRules
-    def self.new: (Locale locale, provider: DataProvider, ?type: plural_rule_type) -> PluralRules
+    def self.new: (Locale locale, ?provider: DataProvider, ?type: plural_rule_type) -> PluralRules
 
     def select: (Integer | Float number) -> plural_category
     def categories: () -> Array[plural_category]
@@ -58,7 +63,7 @@ module ICU4X
   class NumberFormat
     def self.new: (
       Locale locale,
-      provider: DataProvider,
+      ?provider: DataProvider,
       ?style: number_format_style,
       ?currency: String,
       ?use_grouping: bool,
@@ -84,7 +89,7 @@ module ICU4X
   class DateTimeFormat
     def self.new: (
       Locale locale,
-      provider: DataProvider,
+      ?provider: DataProvider,
       ?date_style: date_style,
       ?time_style: time_style,
       ?time_zone: String,
@@ -108,7 +113,7 @@ module ICU4X
   class RelativeTimeFormat
     def self.new: (
       Locale locale,
-      provider: DataProvider,
+      ?provider: DataProvider,
       ?style: relative_time_format_style,
       ?numeric: relative_time_format_numeric
     ) -> RelativeTimeFormat
@@ -130,7 +135,7 @@ module ICU4X
   class ListFormat
     def self.new: (
       Locale locale,
-      provider: DataProvider,
+      ?provider: DataProvider,
       ?type: list_format_type,
       ?style: list_format_style
     ) -> ListFormat
@@ -146,7 +151,7 @@ module ICU4X
   class Collator
     def self.new: (
       Locale locale,
-      provider: DataProvider,
+      ?provider: DataProvider,
       ?sensitivity: collator_sensitivity,
       ?numeric: bool,
       ?case_first: collator_case_first
@@ -168,7 +173,7 @@ module ICU4X
   class DisplayNames
     def self.new: (
       Locale locale,
-      provider: DataProvider,
+      ?provider: DataProvider,
       type: display_names_type,
       ?style: display_names_style,
       ?fallback: display_names_fallback

--- a/spec/icu4x/display_names_spec.rb
+++ b/spec/icu4x/display_names_spec.rb
@@ -54,13 +54,38 @@ RSpec.describe ICU4X::DisplayNames do
       end
     end
 
+    context "with optional provider" do
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV["ICU4X_DATA_PATH"] = valid_blob_path.to_s
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "uses default provider when provider is not specified" do
+        dn = ICU4X::DisplayNames.new(locale, type: :language)
+        expect(dn.of("ja")).to eq("Japanese")
+      end
+    end
+
     context "with invalid arguments" do
       let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
       let(:locale) { ICU4X::Locale.parse("ja") }
 
-      it "raises ArgumentError when missing provider keyword" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV.delete("ICU4X_DATA_PATH")
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "raises ArgumentError when no provider is available" do
         expect { ICU4X::DisplayNames.new(locale, type: :language) }
-          .to raise_error(ArgumentError, /missing keyword: :provider/)
+          .to raise_error(ArgumentError, /No provider specified and no default configured/)
       end
 
       it "raises ArgumentError when missing type keyword" do

--- a/spec/icu4x/list_format_spec.rb
+++ b/spec/icu4x/list_format_spec.rb
@@ -48,13 +48,38 @@ RSpec.describe ICU4X::ListFormat do
       end
     end
 
+    context "with optional provider" do
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV["ICU4X_DATA_PATH"] = valid_blob_path.to_s
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "uses default provider when provider is not specified" do
+        lf = ICU4X::ListFormat.new(locale)
+        expect(lf.format(%w[a b c])).to eq("a, b, and c")
+      end
+    end
+
     context "with invalid arguments" do
       let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
       let(:locale) { ICU4X::Locale.parse("en") }
 
-      it "raises ArgumentError when missing provider keyword" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV.delete("ICU4X_DATA_PATH")
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "raises ArgumentError when no provider is available" do
         expect { ICU4X::ListFormat.new(locale) }
-          .to raise_error(ArgumentError, /missing keyword: :provider/)
+          .to raise_error(ArgumentError, /No provider specified and no default configured/)
       end
 
       it "raises ArgumentError for invalid type" do

--- a/spec/icu4x/number_format_spec.rb
+++ b/spec/icu4x/number_format_spec.rb
@@ -35,10 +35,33 @@ RSpec.describe ICU4X::NumberFormat do
       expect(formatter).to be_a(ICU4X::NumberFormat)
     end
 
+    context "with optional provider" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV["ICU4X_DATA_PATH"] = valid_blob_path.to_s
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "uses default provider when provider is not specified" do
+        formatter = ICU4X::NumberFormat.new(locale)
+        expect(formatter.format(1234)).to eq("1,234")
+      end
+    end
+
     context "with invalid arguments" do
-      it "raises ArgumentError when missing provider keyword" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV.delete("ICU4X_DATA_PATH")
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "raises ArgumentError when no provider is available" do
         expect { ICU4X::NumberFormat.new(locale) }
-          .to raise_error(ArgumentError, /missing keyword: :provider/)
+          .to raise_error(ArgumentError, /No provider specified and no default configured/)
       end
 
       it "raises TypeError when provider is invalid type" do

--- a/spec/icu4x/plural_rules_spec.rb
+++ b/spec/icu4x/plural_rules_spec.rb
@@ -30,13 +30,39 @@ RSpec.describe ICU4X::PluralRules do
       end
     end
 
+    context "with optional provider" do
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV["ICU4X_DATA_PATH"] = valid_blob_path.to_s
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "uses default provider when provider is not specified" do
+        rules = ICU4X::PluralRules.new(locale)
+        expect(rules.select(1)).to eq(:one)
+        expect(rules.select(2)).to eq(:other)
+      end
+    end
+
     context "with invalid arguments" do
       let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
       let(:locale) { ICU4X::Locale.parse("en") }
 
-      it "raises ArgumentError when missing provider keyword" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV.delete("ICU4X_DATA_PATH")
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "raises ArgumentError when no provider is available" do
         expect { ICU4X::PluralRules.new(locale) }
-          .to raise_error(ArgumentError, /missing keyword: :provider/)
+          .to raise_error(ArgumentError, /No provider specified and no default configured/)
       end
 
       it "raises ArgumentError when type is invalid" do

--- a/spec/icu4x/relative_time_format_spec.rb
+++ b/spec/icu4x/relative_time_format_spec.rb
@@ -48,13 +48,38 @@ RSpec.describe ICU4X::RelativeTimeFormat do
       end
     end
 
+    context "with optional provider" do
+      let(:locale) { ICU4X::Locale.parse("en") }
+
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV["ICU4X_DATA_PATH"] = valid_blob_path.to_s
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "uses default provider when provider is not specified" do
+        rtf = ICU4X::RelativeTimeFormat.new(locale)
+        expect(rtf.format(-1, :day)).to eq("1 day ago")
+      end
+    end
+
     context "with invalid arguments" do
       let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
       let(:locale) { ICU4X::Locale.parse("en") }
 
-      it "raises ArgumentError when missing provider keyword" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV.delete("ICU4X_DATA_PATH")
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "raises ArgumentError when no provider is available" do
         expect { ICU4X::RelativeTimeFormat.new(locale) }
-          .to raise_error(ArgumentError, /missing keyword: :provider/)
+          .to raise_error(ArgumentError, /No provider specified and no default configured/)
       end
 
       it "raises ArgumentError for invalid style" do

--- a/spec/icu4x_spec.rb
+++ b/spec/icu4x_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+RSpec.describe ICU4X do
+  let(:fixtures_path) { Pathname.new(__dir__) / "fixtures" }
+  let(:valid_blob_path) { fixtures_path / "test-data.postcard" }
+  let(:nonexistent_path) { fixtures_path / "nonexistent.postcard" }
+
+  describe ".config" do
+    around do |example|
+      original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+      ENV.delete("ICU4X_DATA_PATH")
+      example.run
+    ensure
+      ENV["ICU4X_DATA_PATH"] = original_env
+    end
+
+    it "has a data_path setting that defaults to nil" do
+      expect(ICU4X.config.data_path).to be_nil
+    end
+
+    it "accepts a Pathname for data_path" do
+      ICU4X.configure {|config| config.data_path = valid_blob_path }
+      expect(ICU4X.config.data_path).to eq(valid_blob_path)
+    end
+
+    it "converts String to Pathname for data_path" do
+      ICU4X.configure {|config| config.data_path = valid_blob_path.to_s }
+      expect(ICU4X.config.data_path).to eq(valid_blob_path)
+    end
+  end
+
+  describe ".default_provider" do
+    context "when neither config.data_path nor ENV['ICU4X_DATA_PATH'] is set" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV.delete("ICU4X_DATA_PATH")
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "returns nil" do
+        expect(ICU4X.default_provider).to be_nil
+      end
+    end
+
+    context "when config.data_path is set" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV.delete("ICU4X_DATA_PATH")
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      before { ICU4X.configure {|config| config.data_path = valid_blob_path } }
+
+      it "returns a DataProvider" do
+        expect(ICU4X.default_provider).to be_a(ICU4X::DataProvider)
+      end
+    end
+
+    context "when ENV['ICU4X_DATA_PATH'] is set" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV["ICU4X_DATA_PATH"] = valid_blob_path.to_s
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      it "returns a DataProvider" do
+        expect(ICU4X.default_provider).to be_a(ICU4X::DataProvider)
+      end
+    end
+
+    context "when both config.data_path and ENV['ICU4X_DATA_PATH'] are set" do
+      around do |example|
+        original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+        ENV["ICU4X_DATA_PATH"] = nonexistent_path.to_s
+        example.run
+      ensure
+        ENV["ICU4X_DATA_PATH"] = original_env
+      end
+
+      before { ICU4X.configure {|config| config.data_path = valid_blob_path } }
+
+      it "prioritizes config.data_path over ENV" do
+        # If ENV were used, it would raise an error for nonexistent path
+        expect { ICU4X.default_provider }.not_to raise_error
+      end
+    end
+  end
+
+  describe ".reset_default_provider!" do
+    around do |example|
+      original_env = ENV.fetch("ICU4X_DATA_PATH", nil)
+      ENV.delete("ICU4X_DATA_PATH")
+      example.run
+    ensure
+      ENV["ICU4X_DATA_PATH"] = original_env
+    end
+
+    before { ICU4X.configure {|config| config.data_path = valid_blob_path } }
+
+    it "clears the cached default provider" do
+      ICU4X.default_provider
+      ICU4X.reset_default_provider!
+      ICU4X.reset_config
+      expect(ICU4X.default_provider).to be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,10 @@
 require "simplecov"
 SimpleCov.start
 
+require "dry/configurable/test_interface"
 require "icu4x"
+
+ICU4X.enable_test_interface
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -14,5 +17,11 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  # Reset ICU4X configuration between tests
+  config.before do
+    ICU4X.reset_config
+    ICU4X.reset_default_provider!
   end
 end


### PR DESCRIPTION
## Summary
Make `provider:` argument optional for all formatter classes. When not specified, automatically loads from `ICU4X_DATA_PATH` environment variable or `ICU4X.configure` block.

## Changes
- Add `dry-configurable` gem for configuration management
- Add `ICU4X.default_provider` with thread-safe lazy initialization
- Update all Rust formatters to fall back to default provider
- Make `provider:` optional in RBS type signatures

## Test Plan
- Run `bundle exec rake` (359 tests pass)
- Run `bundle exec steep check` (no type errors)

Closes #19
