### PR TITLE
:recycle: Extract locale extraction logic into helpers.rs

### DIFF
--- a/ext/icu4x/src/collator.rs
+++ b/ext/icu4x/src/collator.rs
@@ -1,6 +1,5 @@
 use crate::data_provider::DataProvider;
 use crate::helpers;
-use crate::locale::Locale;
 use icu::collator::Collator as IcuCollator;
 use icu::collator::CollatorPreferences;
 use icu::collator::options::{CaseLevel, CollatorOptions, Strength};
@@ -79,19 +78,7 @@ impl Collator {
     /// * `case_first:` - :upper, :lower, or nil (default)
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
         // Parse arguments: (locale, **kwargs)
-        if args.is_empty() {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "wrong number of arguments (given 0, expected 1+)",
-            ));
-        }
-
-        // Get the locale
-        let locale: &Locale = TryConvert::try_convert(args[0])?;
-        let locale_ref = locale.inner.borrow();
-        let locale_str = locale_ref.to_string();
-        let icu_locale = locale_ref.clone();
-        drop(locale_ref);
+        let (icu_locale, locale_str) = helpers::extract_locale(ruby, args)?;
 
         // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {

--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -1,6 +1,5 @@
 use crate::data_provider::DataProvider;
 use crate::helpers;
-use crate::locale::Locale;
 use icu::calendar::preferences::CalendarAlgorithm;
 use icu::calendar::{AnyCalendarKind, Date, Gregorian};
 use icu::datetime::fieldsets::enums::{
@@ -162,19 +161,7 @@ impl DateTimeFormat {
     ///   :persian, :indian, :ethiopian, :coptic, :roc, :dangi
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
         // Parse arguments: (locale, **kwargs)
-        if args.is_empty() {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "wrong number of arguments (given 0, expected 1+)",
-            ));
-        }
-
-        // Get the locale
-        let locale: &Locale = TryConvert::try_convert(args[0])?;
-        let locale_ref = locale.inner.borrow();
-        let locale_str = locale_ref.to_string();
-        let icu_locale = locale_ref.clone();
-        drop(locale_ref);
+        let (icu_locale, locale_str) = helpers::extract_locale(ruby, args)?;
 
         // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {

--- a/ext/icu4x/src/display_names.rs
+++ b/ext/icu4x/src/display_names.rs
@@ -1,6 +1,5 @@
 use crate::data_provider::DataProvider;
 use crate::helpers;
-use crate::locale::Locale;
 use icu::experimental::displaynames::{
     DisplayNamesOptions, Fallback, LanguageDisplayNames, LocaleDisplayNamesFormatter,
     RegionDisplayNames, ScriptDisplayNames, Style,
@@ -113,19 +112,7 @@ impl DisplayNames {
     /// * `fallback:` - :code (default) or :none
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
         // Parse arguments: (locale, **kwargs)
-        if args.is_empty() {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "wrong number of arguments (given 0, expected 1+)",
-            ));
-        }
-
-        // Get the locale
-        let locale: &Locale = TryConvert::try_convert(args[0])?;
-        let locale_ref = locale.inner.borrow();
-        let locale_str = locale_ref.to_string();
-        let icu_locale = locale_ref.clone();
-        drop(locale_ref);
+        let (icu_locale, locale_str) = helpers::extract_locale(ruby, args)?;
 
         // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {

--- a/ext/icu4x/src/list_format.rs
+++ b/ext/icu4x/src/list_format.rs
@@ -1,6 +1,5 @@
 use crate::data_provider::DataProvider;
 use crate::helpers;
-use crate::locale::Locale;
 use icu::list::ListFormatter;
 use icu::list::options::{ListFormatterOptions, ListLength};
 use icu_provider::buf::AsDeserializingBufferProvider;
@@ -75,19 +74,7 @@ impl ListFormat {
     /// * `style:` - :long (default), :short, or :narrow
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
         // Parse arguments: (locale, **kwargs)
-        if args.is_empty() {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "wrong number of arguments (given 0, expected 1+)",
-            ));
-        }
-
-        // Get the locale
-        let locale: &Locale = TryConvert::try_convert(args[0])?;
-        let locale_ref = locale.inner.borrow();
-        let locale_str = locale_ref.to_string();
-        let icu_locale = locale_ref.clone();
-        drop(locale_ref);
+        let (icu_locale, locale_str) = helpers::extract_locale(ruby, args)?;
 
         // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {

--- a/ext/icu4x/src/number_format.rs
+++ b/ext/icu4x/src/number_format.rs
@@ -1,6 +1,5 @@
 use crate::data_provider::DataProvider;
 use crate::helpers;
-use crate::locale::Locale;
 use fixed_decimal::{Decimal, SignedRoundingMode, UnsignedRoundingMode};
 use icu::decimal::options::{DecimalFormatterOptions, GroupingStrategy};
 use icu::decimal::{DecimalFormatter, DecimalFormatterPreferences};
@@ -112,19 +111,7 @@ impl NumberFormat {
     /// * `use_grouping:` - Whether to use grouping separators (default: true)
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
         // Parse arguments: (locale, **kwargs)
-        if args.is_empty() {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "wrong number of arguments (given 0, expected 1+)",
-            ));
-        }
-
-        // Get the locale
-        let locale: &Locale = TryConvert::try_convert(args[0])?;
-        let locale_ref = locale.inner.borrow();
-        let locale_str = locale_ref.to_string();
-        let icu_locale = locale_ref.clone();
-        drop(locale_ref);
+        let (icu_locale, locale_str) = helpers::extract_locale(ruby, args)?;
 
         // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {

--- a/ext/icu4x/src/plural_rules.rs
+++ b/ext/icu4x/src/plural_rules.rs
@@ -1,6 +1,5 @@
 use crate::data_provider::DataProvider;
 use crate::helpers;
-use crate::locale::Locale;
 use fixed_decimal::Decimal;
 use icu::plurals::{
     PluralCategory, PluralRuleType, PluralRules as IcuPluralRules, PluralRulesPreferences,
@@ -31,20 +30,7 @@ impl PluralRules {
     /// * `type:` - :cardinal (default) or :ordinal
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
         // Parse arguments: (locale, **kwargs)
-        if args.is_empty() {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "wrong number of arguments (given 0, expected 1+)",
-            ));
-        }
-
-        // Get the locale
-        let locale: &Locale = TryConvert::try_convert(args[0])?;
-        let locale_ref = locale.inner.borrow();
-        let locale_str = locale_ref.to_string();
-        // Clone the locale before dropping the borrow
-        let icu_locale = locale_ref.clone();
-        drop(locale_ref);
+        let (icu_locale, locale_str) = helpers::extract_locale(ruby, args)?;
 
         // Convert to PluralRulesPreferences
         let prefs: PluralRulesPreferences = (&icu_locale).into();

--- a/ext/icu4x/src/relative_time_format.rs
+++ b/ext/icu4x/src/relative_time_format.rs
@@ -1,6 +1,5 @@
 use crate::data_provider::DataProvider;
 use crate::helpers;
-use crate::locale::Locale;
 use fixed_decimal::Decimal;
 use icu::experimental::relativetime::options::Numeric;
 use icu::experimental::relativetime::{
@@ -139,19 +138,7 @@ impl RelativeTimeFormat {
     /// * `numeric:` - :always (default), :auto
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
         // Parse arguments: (locale, **kwargs)
-        if args.is_empty() {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "wrong number of arguments (given 0, expected 1+)",
-            ));
-        }
-
-        // Get the locale
-        let locale: &Locale = TryConvert::try_convert(args[0])?;
-        let locale_ref = locale.inner.borrow();
-        let locale_str = locale_ref.to_string();
-        let icu_locale = locale_ref.clone();
-        drop(locale_ref);
+        let (icu_locale, locale_str) = helpers::extract_locale(ruby, args)?;
 
         // Get kwargs (optional)
         let kwargs: RHash = if args.len() > 1 {


### PR DESCRIPTION
## Summary
Extract duplicated locale extraction logic from 7 formatter classes into a shared helper function.

## Changes
- Add `extract_locale` helper function to `helpers.rs`
- Replace ~10 lines of duplicated code in each formatter with helper call
- Remove unused `crate::locale::Locale` imports from formatter files

## Test Plan
- All 359 tests pass
- Clippy check passes with no warnings

Fixes #22
