### PR TITLE
:recycle: Add FromRubySymbol derive macro for enum conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ version = "0.1.0"
 dependencies = [
  "fixed_decimal",
  "icu",
+ "icu4x_macros",
  "icu_locale",
  "icu_provider",
  "icu_provider_adapters",
@@ -431,6 +432,15 @@ dependencies = [
  "jiff",
  "magnus",
  "tinystr",
+]
+
+[[package]]
+name = "icu4x_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/ext/icu4x/Cargo.toml
+++ b/ext/icu4x/Cargo.toml
@@ -20,3 +20,4 @@ icu = { version = "2.1", features = ["experimental"] }
 fixed_decimal = "0.7"
 tinystr = "0.8"
 jiff = "0.2"
+icu4x_macros = { path = "../icu4x_macros" }

--- a/ext/icu4x_macros/Cargo.toml
+++ b/ext/icu4x_macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "icu4x_macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/ext/icu4x_macros/src/lib.rs
+++ b/ext/icu4x_macros/src/lib.rs
@@ -1,0 +1,95 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, parse_macro_input};
+
+/// Converts a PascalCase identifier to snake_case.
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c.is_uppercase() {
+            if i > 0 {
+                result.push('_');
+            }
+            result.push(c.to_ascii_lowercase());
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Derive macro for converting Ruby symbols to Rust enums.
+///
+/// # Example
+///
+/// ```ignore
+/// #[derive(FromRubySymbol)]
+/// enum RoundingMode {
+///     Ceil,       // matches :ceil
+///     Floor,      // matches :floor
+///     HalfExpand, // matches :half_expand
+/// }
+/// ```
+///
+/// This generates:
+///
+/// ```ignore
+/// impl RoundingMode {
+///     pub fn from_ruby_symbol(ruby: &magnus::Ruby, sym: magnus::Symbol) -> Result<Self, magnus::Error> {
+///         // ... conversion logic
+///     }
+/// }
+/// ```
+#[proc_macro_derive(FromRubySymbol)]
+pub fn from_ruby_symbol_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    // Extract enum variants
+    let variants = match &input.data {
+        syn::Data::Enum(data) => &data.variants,
+        _ => panic!("FromRubySymbol can only be derived for enums"),
+    };
+
+    // Generate match arms for each variant
+    let match_arms = variants.iter().map(|variant| {
+        let variant_name = &variant.ident;
+        let symbol_name = to_snake_case(&variant_name.to_string());
+        quote! {
+            if sym.equal(ruby.to_symbol(#symbol_name))? {
+                return Ok(Self::#variant_name);
+            }
+        }
+    });
+
+    // Generate list of valid symbol names for error message
+    let symbol_names: Vec<String> = variants
+        .iter()
+        .map(|v| format!(":{}", to_snake_case(&v.ident.to_string())))
+        .collect();
+    let valid_symbols = symbol_names.join(", ");
+
+    // Generate the impl
+    let expanded = quote! {
+        impl #name {
+            /// Convert a Ruby symbol to this enum type.
+            ///
+            /// # Arguments
+            /// * `ruby` - Ruby runtime reference
+            /// * `sym` - The symbol to convert
+            /// * `key_name` - The keyword argument name (for error messages)
+            ///
+            /// # Errors
+            /// Returns an error if the symbol doesn't match any variant.
+            pub fn from_ruby_symbol(ruby: &magnus::Ruby, sym: magnus::Symbol, key_name: &str) -> Result<Self, magnus::Error> {
+                #(#match_arms)*
+                Err(magnus::Error::new(
+                    ruby.exception_arg_error(),
+                    format!("{} must be {}", key_name, #valid_symbols),
+                ))
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/spec/icu4x/collator_spec.rb
+++ b/spec/icu4x/collator_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe ICU4X::Collator do
 
       it "raises ArgumentError for invalid sensitivity" do
         expect { ICU4X::Collator.new(locale, provider:, sensitivity: :invalid) }
-          .to raise_error(ArgumentError, /sensitivity must be :base, :accent, :case, or :variant/)
+          .to raise_error(ArgumentError, /sensitivity must be :base, :accent, :case, :variant/)
       end
 
       it "raises ArgumentError for invalid case_first" do
         expect { ICU4X::Collator.new(locale, provider:, case_first: :invalid) }
-          .to raise_error(ArgumentError, /case_first must be :upper, :lower, or nil/)
+          .to raise_error(ArgumentError, /case_first must be :upper, :lower/)
       end
 
       it "raises TypeError when provider is invalid type" do

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -69,12 +69,12 @@ RSpec.describe ICU4X::DateTimeFormat do
 
       it "raises ArgumentError when date_style is invalid" do
         expect { ICU4X::DateTimeFormat.new(locale, provider:, date_style: :invalid) }
-          .to raise_error(ArgumentError, /date_style must be :full, :long, :medium, or :short/)
+          .to raise_error(ArgumentError, /date_style must be :full, :long, :medium, :short/)
       end
 
       it "raises ArgumentError when time_style is invalid" do
         expect { ICU4X::DateTimeFormat.new(locale, provider:, time_style: :invalid) }
-          .to raise_error(ArgumentError, /time_style must be :full, :long, :medium, or :short/)
+          .to raise_error(ArgumentError, /time_style must be :full, :long, :medium, :short/)
       end
 
       it "raises ArgumentError when calendar is invalid" do

--- a/spec/icu4x/display_names_spec.rb
+++ b/spec/icu4x/display_names_spec.rb
@@ -95,17 +95,17 @@ RSpec.describe ICU4X::DisplayNames do
 
       it "raises ArgumentError when type is invalid" do
         expect { ICU4X::DisplayNames.new(locale, provider:, type: :invalid) }
-          .to raise_error(ArgumentError, /type must be :language, :region, :script, or :locale/)
+          .to raise_error(ArgumentError, /type must be :language, :region, :script, :locale/)
       end
 
       it "raises ArgumentError when style is invalid" do
         expect { ICU4X::DisplayNames.new(locale, provider:, type: :language, style: :invalid) }
-          .to raise_error(ArgumentError, /style must be :long, :short, or :narrow/)
+          .to raise_error(ArgumentError, /style must be :long, :short, :narrow/)
       end
 
       it "raises ArgumentError when fallback is invalid" do
         expect { ICU4X::DisplayNames.new(locale, provider:, type: :language, fallback: :invalid) }
-          .to raise_error(ArgumentError, /fallback must be :code or :none/)
+          .to raise_error(ArgumentError, /fallback must be :code, :none/)
       end
 
       it "raises TypeError when provider is invalid type" do

--- a/spec/icu4x/list_format_spec.rb
+++ b/spec/icu4x/list_format_spec.rb
@@ -84,12 +84,12 @@ RSpec.describe ICU4X::ListFormat do
 
       it "raises ArgumentError for invalid type" do
         expect { ICU4X::ListFormat.new(locale, provider:, type: :invalid) }
-          .to raise_error(ArgumentError, /type must be :conjunction, :disjunction, or :unit/)
+          .to raise_error(ArgumentError, /type must be :conjunction, :disjunction, :unit/)
       end
 
       it "raises ArgumentError for invalid style" do
         expect { ICU4X::ListFormat.new(locale, provider:, style: :invalid) }
-          .to raise_error(ArgumentError, /style must be :long, :short, or :narrow/)
+          .to raise_error(ArgumentError, /style must be :long, :short, :narrow/)
       end
 
       it "raises TypeError when provider is invalid type" do

--- a/spec/icu4x/number_format_spec.rb
+++ b/spec/icu4x/number_format_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ICU4X::NumberFormat do
 
       it "raises ArgumentError when style is invalid" do
         expect { ICU4X::NumberFormat.new(locale, provider:, style: :invalid) }
-          .to raise_error(ArgumentError, /style must be :decimal, :percent, or :currency/)
+          .to raise_error(ArgumentError, /style must be :decimal, :percent, :currency/)
       end
 
       it "raises ArgumentError when style is :currency but currency is missing" do

--- a/spec/icu4x/relative_time_format_spec.rb
+++ b/spec/icu4x/relative_time_format_spec.rb
@@ -84,12 +84,12 @@ RSpec.describe ICU4X::RelativeTimeFormat do
 
       it "raises ArgumentError for invalid style" do
         expect { ICU4X::RelativeTimeFormat.new(locale, provider:, style: :invalid) }
-          .to raise_error(ArgumentError, /style must be :long, :short, or :narrow/)
+          .to raise_error(ArgumentError, /style must be :long, :short, :narrow/)
       end
 
       it "raises ArgumentError for invalid numeric" do
         expect { ICU4X::RelativeTimeFormat.new(locale, provider:, numeric: :invalid) }
-          .to raise_error(ArgumentError, /numeric must be :always or :auto/)
+          .to raise_error(ArgumentError, /numeric must be :always, :auto/)
       end
 
       it "raises TypeError when provider is invalid type" do
@@ -270,7 +270,7 @@ RSpec.describe ICU4X::RelativeTimeFormat do
 
       it "raises ArgumentError for invalid unit" do
         expect { rtf.format(-1, :invalid) }
-          .to raise_error(ArgumentError, /unit must be :second, :minute, :hour, :day, :week, :month, :quarter, or :year/)
+          .to raise_error(ArgumentError, /unit must be :second, :minute, :hour, :day, :week, :month, :quarter, :year/)
       end
     end
   end

--- a/spec/icu4x/segmenter_spec.rb
+++ b/spec/icu4x/segmenter_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ICU4X::Segmenter do
 
       it "raises ArgumentError for invalid granularity" do
         expect { ICU4X::Segmenter.new(granularity: :invalid) }
-          .to raise_error(ArgumentError, /granularity must be :grapheme, :word, :sentence, or :line/)
+          .to raise_error(ArgumentError, /granularity must be :grapheme, :word, :sentence, :line/)
       end
 
       it "raises TypeError when provider is invalid type" do


### PR DESCRIPTION
## Summary
Add a `FromRubySymbol` derive macro that generates symbol-to-enum conversion code, eliminating repetitive boilerplate.

## Changes
- Create `icu4x_macros` proc_macro crate with `FromRubySymbol` derive macro
- Apply macro to 16 enums across 7 files (collator, datetime_format, display_names, list_format, number_format, relative_time_format, segmenter)
- Unify error message format for invalid symbol values

## Before
Each enum required 15-40 lines of manual symbol comparison code.

## After
A single `#[derive(FromRubySymbol)]` generates the conversion method automatically.

Closes #25
