### PR TITLE
:recycle: Rename FromRubySymbol to RubySymbol and add to_symbol_name generation

### DIFF
--- a/ext/icu4x/src/collator.rs
+++ b/ext/icu4x/src/collator.rs
@@ -5,7 +5,7 @@ use icu::collator::CollatorPreferences;
 use icu::collator::options::{CaseLevel, CollatorOptions, Strength};
 use icu::collator::preferences::{CollationCaseFirst, CollationNumericOrdering};
 use icu_provider::buf::AsDeserializingBufferProvider;
-use icu4x_macros::FromRubySymbol;
+use icu4x_macros::RubySymbol;
 use magnus::{
     Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
     prelude::*,
@@ -13,7 +13,7 @@ use magnus::{
 use std::cmp::Ordering;
 
 /// Sensitivity level for collation
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum Sensitivity {
     Base,
     Accent,
@@ -21,32 +21,14 @@ enum Sensitivity {
     Variant,
 }
 
-impl Sensitivity {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            Sensitivity::Base => "base",
-            Sensitivity::Accent => "accent",
-            Sensitivity::Case => "case",
-            Sensitivity::Variant => "variant",
-        }
-    }
-}
-
 /// Case first option
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum CaseFirstOption {
     Upper,
     Lower,
 }
 
 impl CaseFirstOption {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            CaseFirstOption::Upper => "upper",
-            CaseFirstOption::Lower => "lower",
-        }
-    }
-
     fn to_icu_case_first(self) -> CollationCaseFirst {
         match self {
             CaseFirstOption::Upper => CollationCaseFirst::Upper,

--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -11,7 +11,7 @@ use icu::datetime::{DateTimeFormatter, DateTimeFormatterPreferences};
 use icu::time::Time;
 use icu::time::zone::IanaParser;
 use icu_provider::buf::AsDeserializingBufferProvider;
-use icu4x_macros::FromRubySymbol;
+use icu4x_macros::RubySymbol;
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
 use magnus::{
@@ -20,7 +20,7 @@ use magnus::{
 };
 
 /// Date style option
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum DateStyle {
     Full,
     Long,
@@ -28,19 +28,8 @@ enum DateStyle {
     Short,
 }
 
-impl DateStyle {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            DateStyle::Full => "full",
-            DateStyle::Long => "long",
-            DateStyle::Medium => "medium",
-            DateStyle::Short => "short",
-        }
-    }
-}
-
 /// Time style option
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum TimeStyle {
     Full,
     Long,
@@ -48,19 +37,8 @@ enum TimeStyle {
     Short,
 }
 
-impl TimeStyle {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            TimeStyle::Full => "full",
-            TimeStyle::Long => "long",
-            TimeStyle::Medium => "medium",
-            TimeStyle::Short => "short",
-        }
-    }
-}
-
 /// Calendar option
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum Calendar {
     Gregory,
     Japanese,
@@ -77,23 +55,6 @@ enum Calendar {
 }
 
 impl Calendar {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            Calendar::Gregory => "gregory",
-            Calendar::Japanese => "japanese",
-            Calendar::Buddhist => "buddhist",
-            Calendar::Chinese => "chinese",
-            Calendar::Hebrew => "hebrew",
-            Calendar::Islamic => "islamic",
-            Calendar::Persian => "persian",
-            Calendar::Indian => "indian",
-            Calendar::Ethiopian => "ethiopian",
-            Calendar::Coptic => "coptic",
-            Calendar::Roc => "roc",
-            Calendar::Dangi => "dangi",
-        }
-    }
-
     fn to_calendar_algorithm(self) -> CalendarAlgorithm {
         match self {
             Calendar::Gregory => CalendarAlgorithm::Gregory,

--- a/ext/icu4x/src/display_names.rs
+++ b/ext/icu4x/src/display_names.rs
@@ -6,14 +6,14 @@ use icu::experimental::displaynames::{
 };
 use icu_locale::LanguageIdentifier;
 use icu_provider::buf::AsDeserializingBufferProvider;
-use icu4x_macros::FromRubySymbol;
+use icu4x_macros::RubySymbol;
 use magnus::{
     Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
     prelude::*,
 };
 
 /// Display name type
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum DisplayNamesType {
     Language,
     Region,
@@ -21,19 +21,8 @@ enum DisplayNamesType {
     Locale,
 }
 
-impl DisplayNamesType {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            DisplayNamesType::Language => "language",
-            DisplayNamesType::Region => "region",
-            DisplayNamesType::Script => "script",
-            DisplayNamesType::Locale => "locale",
-        }
-    }
-}
-
 /// Display name style
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum DisplayNamesStyle {
     Long,
     Short,
@@ -41,14 +30,6 @@ enum DisplayNamesStyle {
 }
 
 impl DisplayNamesStyle {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            DisplayNamesStyle::Long => "long",
-            DisplayNamesStyle::Short => "short",
-            DisplayNamesStyle::Narrow => "narrow",
-        }
-    }
-
     fn to_icu_style(self) -> Style {
         match self {
             DisplayNamesStyle::Long => Style::Long,
@@ -59,20 +40,13 @@ impl DisplayNamesStyle {
 }
 
 /// Display name fallback option
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum DisplayNamesFallback {
     Code,
     None,
 }
 
 impl DisplayNamesFallback {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            DisplayNamesFallback::Code => "code",
-            DisplayNamesFallback::None => "none",
-        }
-    }
-
     fn to_icu_fallback(self) -> Fallback {
         match self {
             DisplayNamesFallback::Code => Fallback::Code,

--- a/ext/icu4x/src/list_format.rs
+++ b/ext/icu4x/src/list_format.rs
@@ -3,32 +3,22 @@ use crate::helpers;
 use icu::list::ListFormatter;
 use icu::list::options::{ListFormatterOptions, ListLength};
 use icu_provider::buf::AsDeserializingBufferProvider;
-use icu4x_macros::FromRubySymbol;
+use icu4x_macros::RubySymbol;
 use magnus::{
     Error, ExceptionClass, RArray, RHash, RModule, Ruby, Symbol, TryConvert, Value, function,
     method, prelude::*,
 };
 
 /// The type of list formatting
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum ListType {
     Conjunction,
     Disjunction,
     Unit,
 }
 
-impl ListType {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            ListType::Conjunction => "conjunction",
-            ListType::Disjunction => "disjunction",
-            ListType::Unit => "unit",
-        }
-    }
-}
-
 /// The style of list formatting
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum ListStyle {
     Long,
     Short,
@@ -41,14 +31,6 @@ impl ListStyle {
             ListStyle::Long => ListLength::Wide,
             ListStyle::Short => ListLength::Short,
             ListStyle::Narrow => ListLength::Narrow,
-        }
-    }
-
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            ListStyle::Long => "long",
-            ListStyle::Short => "short",
-            ListStyle::Narrow => "narrow",
         }
     }
 }

--- a/ext/icu4x/src/number_format.rs
+++ b/ext/icu4x/src/number_format.rs
@@ -13,7 +13,7 @@ use icu::experimental::dimension::percent::formatter::{
 };
 use icu::experimental::dimension::percent::options::PercentFormatterOptions;
 use icu_provider::buf::AsDeserializingBufferProvider;
-use icu4x_macros::FromRubySymbol;
+use icu4x_macros::RubySymbol;
 use magnus::{
     Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
     prelude::*,
@@ -21,7 +21,7 @@ use magnus::{
 use tinystr::TinyAsciiStr;
 
 /// The style of number formatting
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum Style {
     Decimal,
     Percent,
@@ -29,7 +29,7 @@ enum Style {
 }
 
 /// Rounding mode for number formatting
-#[derive(Clone, Copy, PartialEq, Eq, Default, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, RubySymbol)]
 enum RoundingMode {
     Ceil,
     Floor,
@@ -59,20 +59,6 @@ impl RoundingMode {
                 SignedRoundingMode::Unsigned(UnsignedRoundingMode::HalfTrunc)
             }
             RoundingMode::HalfEven => SignedRoundingMode::Unsigned(UnsignedRoundingMode::HalfEven),
-        }
-    }
-
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            RoundingMode::Ceil => "ceil",
-            RoundingMode::Floor => "floor",
-            RoundingMode::Expand => "expand",
-            RoundingMode::Trunc => "trunc",
-            RoundingMode::HalfCeil => "half_ceil",
-            RoundingMode::HalfFloor => "half_floor",
-            RoundingMode::HalfExpand => "half_expand",
-            RoundingMode::HalfTrunc => "half_trunc",
-            RoundingMode::HalfEven => "half_even",
         }
     }
 }

--- a/ext/icu4x/src/relative_time_format.rs
+++ b/ext/icu4x/src/relative_time_format.rs
@@ -6,32 +6,22 @@ use icu::experimental::relativetime::{
     RelativeTimeFormatter, RelativeTimeFormatterOptions, RelativeTimeFormatterPreferences,
 };
 use icu_provider::buf::AsDeserializingBufferProvider;
-use icu4x_macros::FromRubySymbol;
+use icu4x_macros::RubySymbol;
 use magnus::{
     Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
     prelude::*,
 };
 
 /// The style of relative time formatting
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum Style {
     Long,
     Short,
     Narrow,
 }
 
-impl Style {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            Style::Long => "long",
-            Style::Short => "short",
-            Style::Narrow => "narrow",
-        }
-    }
-}
-
 /// The numeric mode for relative time formatting
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum NumericMode {
     Always,
     Auto,
@@ -44,17 +34,10 @@ impl NumericMode {
             NumericMode::Auto => Numeric::Auto,
         }
     }
-
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            NumericMode::Always => "always",
-            NumericMode::Auto => "auto",
-        }
-    }
 }
 
 /// Time unit for relative time formatting
-#[derive(Clone, Copy, PartialEq, Eq, Hash, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, RubySymbol)]
 enum Unit {
     Second,
     Minute,

--- a/ext/icu4x/src/segmenter.rs
+++ b/ext/icu4x/src/segmenter.rs
@@ -6,30 +6,19 @@ use icu::segmenter::{
     WordSegmenterBorrowed,
 };
 use icu_provider::buf::AsDeserializingBufferProvider;
-use icu4x_macros::FromRubySymbol;
+use icu4x_macros::RubySymbol;
 use magnus::{
     Error, ExceptionClass, RArray, RClass, RHash, RModule, Ruby, Symbol, TryConvert, Value,
     function, method, prelude::*,
 };
 
 /// Granularity level for segmentation
-#[derive(Clone, Copy, PartialEq, Eq, FromRubySymbol)]
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
 enum Granularity {
     Grapheme,
     Word,
     Sentence,
     Line,
-}
-
-impl Granularity {
-    fn to_symbol_name(self) -> &'static str {
-        match self {
-            Granularity::Grapheme => "grapheme",
-            Granularity::Word => "word",
-            Granularity::Sentence => "sentence",
-            Granularity::Line => "line",
-        }
-    }
 }
 
 /// Internal segmenter variants - using owned types


### PR DESCRIPTION
## Summary
Rename `FromRubySymbol` derive macro to `RubySymbol` and extend it to generate both `from_ruby_symbol` and `to_symbol_name` methods.

## Changes
- Rename derive macro from `FromRubySymbol` to `RubySymbol`
- Extend macro to generate `to_symbol_name(self) -> &'static str` method
- Remove manual `to_symbol_name` implementations from 14 enums across 7 files

## Before
Each enum required both `#[derive(FromRubySymbol)]` and a manual `to_symbol_name` implementation.

## After
A single `#[derive(RubySymbol)]` generates both methods automatically.

Closes #27
