### PR TITLE
:recycle: Extract symbol option extraction into helper function

### DIFF
--- a/ext/icu4x/src/collator.rs
+++ b/ext/icu4x/src/collator.rs
@@ -7,8 +7,7 @@ use icu::collator::preferences::{CollationCaseFirst, CollationNumericOrdering};
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
-    prelude::*,
+    Error, ExceptionClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 use std::cmp::Ordering;
 
@@ -74,12 +73,9 @@ impl Collator {
         let resolved_provider = helpers::resolve_provider(ruby, &kwargs)?;
 
         // Extract sensitivity option (default: :variant)
-        let sensitivity_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("sensitivity"))?;
-        let sensitivity = match sensitivity_value {
-            Some(sym) => Sensitivity::from_ruby_symbol(ruby, sym, "sensitivity")?,
-            None => Sensitivity::Variant,
-        };
+        let sensitivity =
+            helpers::extract_symbol(ruby, &kwargs, "sensitivity", Sensitivity::from_ruby_symbol)?
+                .unwrap_or(Sensitivity::Variant);
 
         // Extract numeric option (default: false)
         let numeric: bool = kwargs
@@ -87,12 +83,12 @@ impl Collator {
             .unwrap_or(false);
 
         // Extract case_first option (default: nil)
-        let case_first_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("case_first"))?;
-        let case_first = match case_first_value {
-            Some(sym) => Some(CaseFirstOption::from_ruby_symbol(ruby, sym, "case_first")?),
-            None => None,
-        };
+        let case_first = helpers::extract_symbol(
+            ruby,
+            &kwargs,
+            "case_first",
+            CaseFirstOption::from_ruby_symbol,
+        )?;
 
         // Get the error exception class
         let error_class: ExceptionClass = ruby

--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -15,8 +15,7 @@ use icu4x_macros::RubySymbol;
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
 use magnus::{
-    Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
-    prelude::*,
+    Error, ExceptionClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 
 /// Date style option
@@ -136,20 +135,12 @@ impl DateTimeFormat {
         let resolved_provider = helpers::resolve_provider(ruby, &kwargs)?;
 
         // Extract date_style option
-        let date_style_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("date_style"))?;
-        let date_style = match date_style_value {
-            Some(sym) => Some(DateStyle::from_ruby_symbol(ruby, sym, "date_style")?),
-            None => None,
-        };
+        let date_style =
+            helpers::extract_symbol(ruby, &kwargs, "date_style", DateStyle::from_ruby_symbol)?;
 
         // Extract time_style option
-        let time_style_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("time_style"))?;
-        let time_style = match time_style_value {
-            Some(sym) => Some(TimeStyle::from_ruby_symbol(ruby, sym, "time_style")?),
-            None => None,
-        };
+        let time_style =
+            helpers::extract_symbol(ruby, &kwargs, "time_style", TimeStyle::from_ruby_symbol)?;
 
         // At least one of date_style or time_style must be specified
         if date_style.is_none() && time_style.is_none() {
@@ -187,12 +178,8 @@ impl DateTimeFormat {
         };
 
         // Extract calendar option
-        let calendar_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("calendar"))?;
-        let calendar = match calendar_value {
-            Some(sym) => Some(Calendar::from_ruby_symbol(ruby, sym, "calendar")?),
-            None => None,
-        };
+        let calendar =
+            helpers::extract_symbol(ruby, &kwargs, "calendar", Calendar::from_ruby_symbol)?;
 
         // Get the error exception class
         let error_class: ExceptionClass = ruby

--- a/ext/icu4x/src/display_names.rs
+++ b/ext/icu4x/src/display_names.rs
@@ -8,8 +8,7 @@ use icu_locale::LanguageIdentifier;
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
-    prelude::*,
+    Error, ExceptionClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 
 /// Display name type
@@ -100,26 +99,23 @@ impl DisplayNames {
         let resolved_provider = helpers::resolve_provider(ruby, &kwargs)?;
 
         // Extract type (required)
-        let type_value: Symbol = kwargs
-            .lookup::<_, Option<Symbol>>(ruby.to_symbol("type"))?
-            .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :type"))?;
-        let display_type = DisplayNamesType::from_ruby_symbol(ruby, type_value, "type")?;
+        let display_type =
+            helpers::extract_symbol(ruby, &kwargs, "type", DisplayNamesType::from_ruby_symbol)?
+                .ok_or_else(|| Error::new(ruby.exception_arg_error(), "missing keyword: :type"))?;
 
         // Extract style option (default: :long)
-        let style_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("style"))?;
-        let style = match style_value {
-            Some(sym) => DisplayNamesStyle::from_ruby_symbol(ruby, sym, "style")?,
-            None => DisplayNamesStyle::Long,
-        };
+        let style =
+            helpers::extract_symbol(ruby, &kwargs, "style", DisplayNamesStyle::from_ruby_symbol)?
+                .unwrap_or(DisplayNamesStyle::Long);
 
         // Extract fallback option (default: :code)
-        let fallback_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("fallback"))?;
-        let fallback = match fallback_value {
-            Some(sym) => DisplayNamesFallback::from_ruby_symbol(ruby, sym, "fallback")?,
-            None => DisplayNamesFallback::Code,
-        };
+        let fallback = helpers::extract_symbol(
+            ruby,
+            &kwargs,
+            "fallback",
+            DisplayNamesFallback::from_ruby_symbol,
+        )?
+        .unwrap_or(DisplayNamesFallback::Code);
 
         // Get the error exception class
         let error_class: ExceptionClass = ruby

--- a/ext/icu4x/src/list_format.rs
+++ b/ext/icu4x/src/list_format.rs
@@ -5,8 +5,8 @@ use icu::list::options::{ListFormatterOptions, ListLength};
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RArray, RHash, RModule, Ruby, Symbol, TryConvert, Value, function,
-    method, prelude::*,
+    Error, ExceptionClass, RArray, RHash, RModule, Ruby, TryConvert, Value, function, method,
+    prelude::*,
 };
 
 /// The type of list formatting
@@ -70,20 +70,13 @@ impl ListFormat {
         let resolved_provider = helpers::resolve_provider(ruby, &kwargs)?;
 
         // Extract type option (default: :conjunction)
-        let type_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("type"))?;
-        let list_type = match type_value {
-            Some(sym) => ListType::from_ruby_symbol(ruby, sym, "type")?,
-            None => ListType::Conjunction,
-        };
+        let list_type = helpers::extract_symbol(ruby, &kwargs, "type", ListType::from_ruby_symbol)?
+            .unwrap_or(ListType::Conjunction);
 
         // Extract style option (default: :long)
-        let style_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("style"))?;
-        let list_style = match style_value {
-            Some(sym) => ListStyle::from_ruby_symbol(ruby, sym, "style")?,
-            None => ListStyle::Long,
-        };
+        let list_style =
+            helpers::extract_symbol(ruby, &kwargs, "style", ListStyle::from_ruby_symbol)?
+                .unwrap_or(ListStyle::Long);
 
         // Get the error exception class
         let error_class: ExceptionClass = ruby

--- a/ext/icu4x/src/number_format.rs
+++ b/ext/icu4x/src/number_format.rs
@@ -15,8 +15,7 @@ use icu::experimental::dimension::percent::options::PercentFormatterOptions;
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method,
-    prelude::*,
+    Error, ExceptionClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 use tinystr::TinyAsciiStr;
 
@@ -111,12 +110,8 @@ impl NumberFormat {
         let resolved_provider = helpers::resolve_provider(ruby, &kwargs)?;
 
         // Extract style option (default: :decimal)
-        let style_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("style"))?;
-        let style = match style_value {
-            Some(sym) => Style::from_ruby_symbol(ruby, sym, "style")?,
-            None => Style::Decimal,
-        };
+        let style = helpers::extract_symbol(ruby, &kwargs, "style", Style::from_ruby_symbol)?
+            .unwrap_or(Style::Decimal);
 
         // Extract currency option (required for currency style)
         let currency_str: Option<String> =
@@ -143,12 +138,13 @@ impl NumberFormat {
             Self::extract_digit_option(ruby, &kwargs, "maximum_fraction_digits")?;
 
         // Extract rounding_mode option (default: :half_expand)
-        let rounding_mode_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("rounding_mode"))?;
-        let rounding_mode = match rounding_mode_value {
-            Some(sym) => RoundingMode::from_ruby_symbol(ruby, sym, "rounding_mode")?,
-            None => RoundingMode::default(),
-        };
+        let rounding_mode = helpers::extract_symbol(
+            ruby,
+            &kwargs,
+            "rounding_mode",
+            RoundingMode::from_ruby_symbol,
+        )?
+        .unwrap_or_default();
 
         // Get the error exception class
         let error_class: ExceptionClass = ruby

--- a/ext/icu4x/src/relative_time_format.rs
+++ b/ext/icu4x/src/relative_time_format.rs
@@ -101,20 +101,13 @@ impl RelativeTimeFormat {
         let resolved_provider = helpers::resolve_provider(ruby, &kwargs)?;
 
         // Extract style option (default: :long)
-        let style_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("style"))?;
-        let style = match style_value {
-            Some(sym) => Style::from_ruby_symbol(ruby, sym, "style")?,
-            None => Style::Long,
-        };
+        let style = helpers::extract_symbol(ruby, &kwargs, "style", Style::from_ruby_symbol)?
+            .unwrap_or(Style::Long);
 
         // Extract numeric option (default: :always)
-        let numeric_value: Option<Symbol> =
-            kwargs.lookup::<_, Option<Symbol>>(ruby.to_symbol("numeric"))?;
-        let numeric = match numeric_value {
-            Some(sym) => NumericMode::from_ruby_symbol(ruby, sym, "numeric")?,
-            None => NumericMode::Always,
-        };
+        let numeric =
+            helpers::extract_symbol(ruby, &kwargs, "numeric", NumericMode::from_ruby_symbol)?
+                .unwrap_or(NumericMode::Always);
 
         // Get the error exception class
         let error_class: ExceptionClass = ruby


### PR DESCRIPTION
## Summary
Add `extract_symbol` helper function to reduce code duplication in symbol option extraction.

## Changes
- Add generic `extract_symbol` helper function to `helpers.rs`
- Consolidate 16 symbol extraction occurrences across 7 files
- Support three patterns: default value, optional, and required

Closes #29
