### PR TITLE
:recycle: Extract exception class resolution into helper function

### DIFF
--- a/ext/icu4x/src/collator.rs
+++ b/ext/icu4x/src/collator.rs
@@ -7,7 +7,7 @@ use icu::collator::preferences::{CollationCaseFirst, CollationNumericOrdering};
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
+    Error, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 use std::cmp::Ordering;
 
@@ -91,9 +91,7 @@ impl Collator {
         )?;
 
         // Get the error exception class
-        let error_class: ExceptionClass = ruby
-            .eval("ICU4X::Error")
-            .unwrap_or_else(|_| ruby.exception_runtime_error());
+        let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
         // Get the DataProvider
         let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {

--- a/ext/icu4x/src/data_generator.rs
+++ b/ext/icu4x/src/data_generator.rs
@@ -1,10 +1,11 @@
+use crate::helpers;
 use icu_provider::DataMarkerInfo;
 use icu_provider_blob::export::BlobExporter;
 use icu_provider_export::prelude::*;
 use icu_provider_source::SourceDataProvider;
 use magnus::{
-    Error, ExceptionClass, RArray, RClass, RHash, RModule, Ruby, Symbol, Value, function,
-    prelude::*, value::ReprValue,
+    Error, RArray, RClass, RHash, RModule, Ruby, Symbol, Value, function, prelude::*,
+    value::ReprValue,
 };
 use std::collections::HashMap;
 use std::fs::File;
@@ -207,9 +208,7 @@ impl DataGenerator {
         let exporter = BlobExporter::new_with_sink(Box::new(sink));
 
         driver.export(&source_provider, exporter).map_err(|e| {
-            let error_class: ExceptionClass = ruby
-                .eval("ICU4X::DataGeneratorError")
-                .unwrap_or_else(|_| ruby.exception_runtime_error());
+            let error_class = helpers::get_exception_class(ruby, "ICU4X::DataGeneratorError");
             Error::new(error_class, format!("Data export failed: {}", e))
         })?;
 

--- a/ext/icu4x/src/data_provider.rs
+++ b/ext/icu4x/src/data_provider.rs
@@ -1,9 +1,10 @@
+use crate::helpers;
 use icu::locale::fallback::LocaleFallbacker;
 use icu_provider_adapters::fallback::LocaleFallbackProvider;
 use icu_provider_blob::BlobDataProvider;
 use magnus::{
-    Error, ExceptionClass, RClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function,
-    prelude::*, value::ReprValue,
+    Error, RClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, prelude::*,
+    value::ReprValue,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -108,13 +109,8 @@ impl DataProvider {
         let blob_provider =
             BlobDataProvider::try_new_from_static_blob(static_blob).map_err(|e| {
                 // Get the DataError exception class
-                let data_error_class: ExceptionClass = ruby
-                    .eval("ICU4X::DataError")
-                    .unwrap_or_else(|_| ruby.exception_runtime_error());
-                Error::new(
-                    data_error_class,
-                    format!("Failed to create data provider: {}", e),
-                )
+                let data_error_class = helpers::get_exception_class(ruby, "ICU4X::DataError");
+                Error::new(data_error_class, format!("Failed to create data provider: {}", e))
             })?;
 
         // Create the LocaleFallbacker with compiled data

--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -15,7 +15,7 @@ use icu4x_macros::RubySymbol;
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
 use magnus::{
-    Error, ExceptionClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
+    Error, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 
 /// Date style option
@@ -182,9 +182,7 @@ impl DateTimeFormat {
             helpers::extract_symbol(ruby, &kwargs, "calendar", Calendar::from_ruby_symbol)?;
 
         // Get the error exception class
-        let error_class: ExceptionClass = ruby
-            .eval("ICU4X::Error")
-            .unwrap_or_else(|_| ruby.exception_runtime_error());
+        let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
         // Get the DataProvider
         let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {

--- a/ext/icu4x/src/display_names.rs
+++ b/ext/icu4x/src/display_names.rs
@@ -8,7 +8,7 @@ use icu_locale::LanguageIdentifier;
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
+    Error, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 
 /// Display name type
@@ -118,9 +118,7 @@ impl DisplayNames {
         .unwrap_or(DisplayNamesFallback::Code);
 
         // Get the error exception class
-        let error_class: ExceptionClass = ruby
-            .eval("ICU4X::Error")
-            .unwrap_or_else(|_| ruby.exception_runtime_error());
+        let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
         // Get the DataProvider
         let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {

--- a/ext/icu4x/src/helpers.rs
+++ b/ext/icu4x/src/helpers.rs
@@ -1,6 +1,6 @@
 use crate::locale::Locale;
 use icu_locale::Locale as IcuLocale;
-use magnus::{Error, RHash, RModule, Ruby, Symbol, TryConvert, Value, prelude::*};
+use magnus::{Error, ExceptionClass, RHash, RModule, Ruby, Symbol, TryConvert, Value, prelude::*};
 
 /// Resolves the provider from kwargs or falls back to the default provider.
 ///
@@ -25,6 +25,19 @@ pub fn resolve_provider(ruby: &Ruby, kwargs: &RHash) -> Result<Value, Error> {
             Ok(default)
         }
     }
+}
+
+/// Gets the specified exception class, falling back to RuntimeError.
+///
+/// # Arguments
+/// * `ruby` - The Ruby runtime reference
+/// * `name` - The fully qualified exception class name (e.g., "ICU4X::Error")
+///
+/// # Returns
+/// The requested exception class, or RuntimeError if not found.
+pub fn get_exception_class(ruby: &Ruby, name: &str) -> ExceptionClass {
+    ruby.eval(name)
+        .unwrap_or_else(|_| ruby.exception_runtime_error())
 }
 
 /// Extracts and validates the locale from variadic arguments.

--- a/ext/icu4x/src/list_format.rs
+++ b/ext/icu4x/src/list_format.rs
@@ -5,8 +5,7 @@ use icu::list::options::{ListFormatterOptions, ListLength};
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RArray, RHash, RModule, Ruby, TryConvert, Value, function, method,
-    prelude::*,
+    Error, RArray, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 
 /// The type of list formatting
@@ -79,9 +78,7 @@ impl ListFormat {
                 .unwrap_or(ListStyle::Long);
 
         // Get the error exception class
-        let error_class: ExceptionClass = ruby
-            .eval("ICU4X::Error")
-            .unwrap_or_else(|_| ruby.exception_runtime_error());
+        let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
         // Get the DataProvider
         let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {

--- a/ext/icu4x/src/locale.rs
+++ b/ext/icu4x/src/locale.rs
@@ -1,5 +1,6 @@
+use crate::helpers;
 use icu_locale::Locale as IcuLocale;
-use magnus::{Error, ExceptionClass, RHash, RModule, Ruby, function, method, prelude::*};
+use magnus::{Error, RHash, RModule, Ruby, function, method, prelude::*};
 use std::cell::RefCell;
 
 /// Ruby wrapper for ICU4X Locale
@@ -9,17 +10,11 @@ pub struct Locale {
 }
 
 impl Locale {
-    /// Get the LocaleError exception class
-    fn locale_error_class(ruby: &Ruby) -> ExceptionClass {
-        ruby.eval("ICU4X::LocaleError")
-            .unwrap_or_else(|_| ruby.exception_runtime_error())
-    }
-
     /// Parse a BCP 47 locale string
     fn parse(ruby: &Ruby, s: String) -> Result<Self, Error> {
         let locale: IcuLocale = s.parse().map_err(|e| {
             Error::new(
-                Self::locale_error_class(ruby),
+                helpers::get_exception_class(ruby, "ICU4X::LocaleError"),
                 format!("Invalid locale: {e}"),
             )
         })?;
@@ -43,7 +38,7 @@ impl Locale {
         // Handle empty string
         if posix_str.is_empty() {
             return Err(Error::new(
-                Self::locale_error_class(ruby),
+                helpers::get_exception_class(ruby, "ICU4X::LocaleError"),
                 "Invalid POSIX locale: empty string",
             ));
         }
@@ -71,7 +66,7 @@ impl Locale {
             Some(lang) if !lang.is_empty() => *lang,
             _ => {
                 return Err(Error::new(
-                    Self::locale_error_class(ruby),
+                    helpers::get_exception_class(ruby, "ICU4X::LocaleError"),
                     format!("Invalid POSIX locale: {}", posix_str),
                 ));
             }

--- a/ext/icu4x/src/number_format.rs
+++ b/ext/icu4x/src/number_format.rs
@@ -15,7 +15,7 @@ use icu::experimental::dimension::percent::options::PercentFormatterOptions;
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
+    Error, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 use tinystr::TinyAsciiStr;
 
@@ -147,9 +147,7 @@ impl NumberFormat {
         .unwrap_or_default();
 
         // Get the error exception class
-        let error_class: ExceptionClass = ruby
-            .eval("ICU4X::Error")
-            .unwrap_or_else(|_| ruby.exception_runtime_error());
+        let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
         // Get the DataProvider
         let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {

--- a/ext/icu4x/src/plural_rules.rs
+++ b/ext/icu4x/src/plural_rules.rs
@@ -6,8 +6,7 @@ use icu::plurals::{
 };
 use icu_provider::buf::AsDeserializingBufferProvider;
 use magnus::{
-    Error, ExceptionClass, RArray, RHash, RModule, Ruby, Symbol, TryConvert, Value, function,
-    method, prelude::*,
+    Error, RArray, RHash, RModule, Ruby, Symbol, TryConvert, Value, function, method, prelude::*,
 };
 
 /// Ruby wrapper for ICU4X PluralRules
@@ -64,9 +63,7 @@ impl PluralRules {
         };
 
         // Get the error exception class
-        let error_class: ExceptionClass = ruby
-            .eval("ICU4X::Error")
-            .unwrap_or_else(|_| ruby.exception_runtime_error());
+        let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
         // Get the DataProvider
         let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {

--- a/ext/icu4x/src/relative_time_format.rs
+++ b/ext/icu4x/src/relative_time_format.rs
@@ -110,9 +110,7 @@ impl RelativeTimeFormat {
                 .unwrap_or(NumericMode::Always);
 
         // Get the error exception class
-        let error_class: ExceptionClass = ruby
-            .eval("ICU4X::Error")
-            .unwrap_or_else(|_| ruby.exception_runtime_error());
+        let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
         // Get the DataProvider
         let dp: &DataProvider = TryConvert::try_convert(resolved_provider).map_err(|_| {

--- a/ext/icu4x/src/segmenter.rs
+++ b/ext/icu4x/src/segmenter.rs
@@ -9,8 +9,7 @@ use icu::segmenter::{
 use icu_provider::buf::AsDeserializingBufferProvider;
 use icu4x_macros::RubySymbol;
 use magnus::{
-    Error, ExceptionClass, RArray, RClass, RHash, RModule, Ruby, TryConvert, Value, function,
-    method, prelude::*,
+    Error, RArray, RClass, RHash, RModule, Ruby, TryConvert, Value, function, method, prelude::*,
 };
 
 /// Granularity level for segmentation
@@ -71,9 +70,7 @@ impl Segmenter {
             kwargs.lookup::<_, Option<Value>>(ruby.to_symbol("provider"))?;
 
         // Get the error exception class
-        let error_class: ExceptionClass = ruby
-            .eval("ICU4X::Error")
-            .unwrap_or_else(|_| ruby.exception_runtime_error());
+        let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
         // Create the appropriate segmenter
         let inner = match granularity {


### PR DESCRIPTION
## Summary

Extract the repetitive exception class resolution pattern into a reusable helper function.

## Changes

- Add generic `get_exception_class` helper function to `helpers.rs`
- Replace 11 occurrences of inline exception class resolution across 11 files
- Remove `locale_error_class` private method from `locale.rs`
- Remove unused `ExceptionClass` imports

Fixes #31
