### PR TITLE
:bug: Remove Ruby 4.0 from cross-compile targets

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -54,7 +54,7 @@ jobs:
       id: cross-gem
       with:
         platform: ${{ matrix.platform }}
-        ruby-versions: "3.2,3.3,3.4,4.0"
+        ruby-versions: "3.2,3.3,3.4"
 
     - name: Upload cross-compiled gem
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Remove Ruby 4.0 from cross-compilation targets as rb-sys-dock images do not yet support it.

## Background

Ruby 4.0 was released on December 25, 2025, but the rb-sys-dock Docker images used for cross-compilation have not yet been updated to include Ruby 4.0 binaries.

## Impact

- Precompiled gems will be available for Ruby 3.2, 3.3, and 3.4
- Ruby 4.0 users can still install the gem (it will compile from source)
- CI tests still run on Ruby 4.0

## Future

Once rb-sys-dock images are updated with Ruby 4.0 support, this can be reverted.
