### PR TITLE
:bug: Fix cross-compilation missing native:platform tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,10 @@ CLEAN.include("coverage", ".rspec_status", ".yardoc")
 CLOBBER.include("doc/api", "pkg", "lib/**/*.bundle", "lib/**/*.so", "lib/**/*.dll", "spec/fixtures/*.postcard")
 
 require "rb_sys/extensiontask"
-RbSys::ExtensionTask.new("icu4x") do |ext|
+
+gemspec = Gem::Specification.load("icu4x.gemspec")
+
+RbSys::ExtensionTask.new("icu4x", gemspec) do |ext|
   ext.lib_dir = "lib/icu4x"
   ext.cross_compile = true
   ext.cross_platform = %w[


### PR DESCRIPTION
## Summary

Fix cross-compilation failure by passing gemspec to `RbSys::ExtensionTask`.

## Changes

- Load gemspec and pass it as second argument to `RbSys::ExtensionTask.new()`
- This enables `native:platform` tasks required by rb-sys-dock

## Root Cause

Without the gemspec, `RbSys::ExtensionTask` does not define `native:platform` tasks, causing `rb-sys-dock --build` to fail with "Don't know how to build task 'native:arm64-darwin'".

See: https://github.com/oxidize-rb/rb-sys/issues/249

## Test Plan

- `bundle exec rake spec` passes
- `bundle exec rake -P | grep native` now shows native tasks

Fixes #47
