### PR TITLE
:bug: Fix CI not triggering on workflow-created release PRs

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         fetch-depth: 0
+        token: ${{ secrets.WORKFLOW_UPDATE_TOKEN }}
 
     - name: Set git user
       uses: git-actions/set-user@v1
@@ -90,7 +91,7 @@ jobs:
 
     - name: Create Pull Request
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.WORKFLOW_UPDATE_TOKEN }}
       run: |
         # Generate PR body based on whether this is the first release
         if [ "${{ steps.check_first_release.outputs.is_first_release }}" = "true" ]; then


### PR DESCRIPTION
## Summary

Fix CI not triggering on release PRs created by the release-preparation workflow.

## Changes

- Use `WORKFLOW_UPDATE_TOKEN` (PAT) for checkout to enable push with PAT credentials
- Use `WORKFLOW_UPDATE_TOKEN` for PR creation instead of `GITHUB_TOKEN`

## Root Cause

GitHub Actions prevents workflows from triggering on events created by `GITHUB_TOKEN` to avoid infinite loops. Using a PAT bypasses this restriction.

Fixes #49
