### PR TITLE
:bug: Fix validate-release tag check logic

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -57,16 +57,15 @@ jobs:
           exit 1
         fi
 
-    - name: Check if git tag already exists
+    - name: Verify git tag exists
       run: |
+        # Tag should exist because release-preparation creates it before the PR
         if git tag | grep -q "^${{ steps.version.outputs.tag }}$"; then
-          if [ "${{ github.event.action }}" != "synchronize" ]; then
-            echo "❌ Error: Git tag ${{ steps.version.outputs.tag }} already exists"
-            echo "This should only happen if the tag was created outside the release process"
-            exit 1
-          else
-            echo "Tag ${{ steps.version.outputs.tag }} exists and will be updated to latest commit"
-          fi
+          echo "✅ Git tag ${{ steps.version.outputs.tag }} exists"
+        else
+          echo "❌ Error: Git tag ${{ steps.version.outputs.tag }} does not exist"
+          echo "The release-preparation workflow should have created this tag"
+          exit 1
         fi
 
     - name: Check if version already released on RubyGems
@@ -107,10 +106,9 @@ jobs:
         echo "✅ Release validation passed for v${{ steps.version.outputs.version }}"
         echo "- Version format is valid"
         echo "- Version consistency verified"
+        echo "- Git tag exists"
         if [ "${{ github.event.action }}" == "synchronize" ]; then
           echo "- Git tag updated to latest commit"
-        else
-          echo "- Git tag validated"
         fi
         echo "- Version not yet on RubyGems"
         echo "- CHANGELOG.md is properly formatted"


### PR DESCRIPTION
## Summary

Fix validate-release workflow to expect the git tag to exist instead of failing when it exists.

## Changes

- Changed "Check if git tag already exists" to "Verify git tag exists"
- Now fails if tag does NOT exist (since release-preparation creates it before PR)
- Updated summary message

## Root Cause

The release-preparation workflow creates the tag before creating the PR:
1. Create release branch
2. Commit changes
3. **Create tag** ← tag created here
4. Push branch and tag
5. Create PR ← PR opened here, tag already exists

The previous check failed when the tag existed on PR open, which is always true for workflow-created release PRs.

Fixes #53
