### PR TITLE
:bug: Include icu4x_macros and Cargo workspace files in source gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Include `icu4x_macros` crate and Cargo workspace files in source gem (#57)
+
 ## [0.5.0] - 2026-01-01
 
 ### Added

--- a/icu4x.gemspec
+++ b/icu4x.gemspec
@@ -23,9 +23,13 @@ Gem::Specification.new do |spec|
     Dir[
       "lib/icu4x.rb",
       "lib/icu4x/**/*.rb",
+      "Cargo.toml",
+      "Cargo.lock",
       "ext/icu4x/extconf.rb",
       "ext/icu4x/Cargo.toml",
       "ext/icu4x/**/*.rs",
+      "ext/icu4x_macros/Cargo.toml",
+      "ext/icu4x_macros/**/*.rs",
       "sig/icu4x.rbs",
       "LICENSE.txt",
       "README.md",


### PR DESCRIPTION
## Summary

Fix source gem to include missing files required for native extension build on platforms without precompiled binaries.

## Changes

- Add root `Cargo.toml` and `Cargo.lock` to gemspec
- Add `ext/icu4x_macros` directory to gemspec
- Update CHANGELOG

Fixes #57
