### PR TITLE
:wrench: Rename WORKFLOW_UPDATE_TOKEN to WORKFLOW_TOKEN

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         fetch-depth: 0
-        token: ${{ secrets.WORKFLOW_UPDATE_TOKEN }}
+        token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Set git user
       uses: git-actions/set-user@v1
@@ -91,7 +91,7 @@ jobs:
 
     - name: Create Pull Request
       env:
-        GH_TOKEN: ${{ secrets.WORKFLOW_UPDATE_TOKEN }}
+        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       run: |
         # Generate PR body based on whether this is the first release
         if [ "${{ steps.check_first_release.outputs.is_first_release }}" = "true" ]; then

--- a/.github/workflows/update-ruby-versions.yml
+++ b/.github/workflows/update-ruby-versions.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.WORKFLOW_UPDATE_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Get Ruby versions and update files
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           # Get Ruby versions directly from branches.yml
           ruby_data=$(gh api -H "Accept: application/vnd.github.raw" repos/ruby/www.ruby-lang.org/contents/_data/branches.yml | \
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           # Check if there are changes
           if git diff --quiet .rubocop.yml mise.toml .github/workflows/ci.yml .github/workflows/release-*.yml *.gemspec; then


### PR DESCRIPTION
## Summary

Rename PAT secret from `WORKFLOW_UPDATE_TOKEN` to `WORKFLOW_TOKEN` for clarity.

## Changes

- Update `update-ruby-versions.yml` to use `WORKFLOW_TOKEN`
- Update `release-preparation.yml` to use `WORKFLOW_TOKEN`

## Required Manual Steps

Before merging:
1. Create new Fine-grained PAT named `WORKFLOW_TOKEN` with permissions:
   - Contents: Read and Write
   - Pull requests: Read and Write
   - Workflows: Read and Write
2. Add the new token as repository secret

After merging:
1. Delete old `WORKFLOW_UPDATE_TOKEN` secret

Fixes #56
