### PR TITLE
:bug: Fix native extension loader for precompiled gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Fix native extension loader for precompiled gems (#61)
+
 ## [0.5.1] - 2026-01-01
 
 ### Fixed

--- a/lib/icu4x.rb
+++ b/lib/icu4x.rb
@@ -3,7 +3,13 @@
 require "dry-configurable"
 require "pathname"
 
-require_relative "icu4x/icu4x" # Native extension
+# Native extension - try version-specific path for precompiled gems first
+begin
+  RUBY_VERSION =~ /\A(\d+\.\d+)/
+  require_relative "icu4x/#{$1}/icu4x"
+rescue LoadError
+  require_relative "icu4x/icu4x"
+end
 require_relative "icu4x/version"
 
 # ICU4X provides Ruby bindings for ICU4X, a Unicode library.


### PR DESCRIPTION
## Summary

Fix native extension loading for precompiled gems by using version-specific paths.

## Changes

- Update loader to try version-specific path first (e.g., `lib/icu4x/3.2/icu4x`)
- Fall back to direct path for source builds

Fixes #61
