### PR TITLE
:sparkles: Auto-include 'und' locale in DataGenerator.export

### DIFF
--- a/doc/data.md
+++ b/doc/data.md
@@ -196,6 +196,7 @@ provider = ICU4X::DataProvider.from_blob(Pathname.new("path/to/data.blob"), prio
 - Fallback follows the locale hierarchy, not arbitrary language preferences.
   - Example: `ja` will NOT fall back to `en`. It falls back to `und` (undetermined).
 - For data to be available via fallback, it must be included when generating the blob file.
+- The `und` locale is automatically included when generating data to ensure fallback support.
 
 ---
 
@@ -209,6 +210,7 @@ A class for generating locale data blob files.
 module ICU4X
   class DataGenerator
     # Export locale data
+    # The `und` locale is automatically included for fallback support.
     # @param locales [Array<String>] Locales to include
     # @param markers [Symbol, Array<String>] Data markers (:all or specific markers)
     # @param format [Symbol] Output format (:blob)

--- a/ext/icu4x/src/data_generator.rs
+++ b/ext/icu4x/src/data_generator.rs
@@ -75,12 +75,17 @@ impl DataGenerator {
             locale_families.push(family);
         }
 
-        // Warn if 'und' locale is not included
+        // Automatically include 'und' locale if not specified
         if !has_und {
+            let family = DataLocaleFamily::with_descendants(
+                "und".parse().expect("'und' is a valid locale"),
+            );
+            locale_families.push(family);
+
             let kernel: Value = ruby.eval("Kernel")?;
             let _: Value = kernel.funcall(
                 "warn",
-                ("ICU4X::DataGenerator.export: 'und' locale not included. Fallback may fail for unlisted locales.",),
+                ("ICU4X::DataGenerator.export: 'und' locale automatically included for fallback support.",),
             )?;
         }
 

--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -112,6 +112,9 @@
 #     class DataGenerator
 #       # Exports locale data to a file.
 #       #
+#       # The +und+ (undetermined) locale is automatically included if not specified,
+#       # as it provides essential fallback data for ICU4X operations.
+#       #
 #       # @param locales [Array<String>] list of locale identifiers to include
 #       # @param markers [Symbol, Array<String>] data markers to include;
 #       #   use +:all+ for all markers, or specify individual marker names

--- a/spec/icu4x/data_generator_spec.rb
+++ b/spec/icu4x/data_generator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ICU4X::DataGenerator do
         expect(output_path.size).to be > 0
       end
 
-      it "warns when 'und' locale is not included", :slow do
+      it "warns when 'und' locale is automatically included", :slow do
         ICU4X::DataGenerator.export(
           locales: %w[en],
           markers: %w[PluralsCardinalV1],
@@ -37,7 +37,7 @@ RSpec.describe ICU4X::DataGenerator do
           output: output_path
         )
 
-        expect(Kernel).to have_received(:warn).with(/'und' locale not included/)
+        expect(Kernel).to have_received(:warn).with(/'und' locale automatically included/)
       end
 
       it "does not warn when 'und' locale is included", :slow do


### PR DESCRIPTION
## Summary
Automatically include the `und` (undetermined) locale when generating data with `DataGenerator.export`, ensuring fallback support is always available.

## Changes
- Add `und` locale to export when not explicitly specified
- Issue warning to notify user of automatic inclusion
- Update documentation (YARD, doc/data.md)

## Test Plan
- Run `bundle exec rspec spec/icu4x/data_generator_spec.rb`
- Verify warning message appears when `und` is not in locales

Fixes #64
