### PR TITLE
:sparkles: Add symbolic locale specifiers to DataGenerator.export

### DIFF
--- a/doc/data.md
+++ b/doc/data.md
@@ -196,7 +196,7 @@ provider = ICU4X::DataProvider.from_blob(Pathname.new("path/to/data.blob"), prio
 - Fallback follows the locale hierarchy, not arbitrary language preferences.
   - Example: `ja` will NOT fall back to `en`. It falls back to `und` (undetermined).
 - For data to be available via fallback, it must be included when generating the blob file.
-- The `und` locale is automatically included when generating data to ensure fallback support.
+- When specifying locales, ancestor locales (including `und`) are automatically included via `with_descendants`.
 
 ---
 
@@ -210,8 +210,13 @@ A class for generating locale data blob files.
 module ICU4X
   class DataGenerator
     # Export locale data
-    # The `und` locale is automatically included for fallback support.
-    # @param locales [Array<String>] Locales to include
+    # @param locales [Symbol, Array<String>] Locale specification:
+    #   - :full - all CLDR locales (700+)
+    #   - :recommended - basic + moderate + modern coverage (164)
+    #   - :modern - modern coverage only (103)
+    #   - :moderate - moderate coverage only
+    #   - :basic - basic coverage only
+    #   - Array<String> - explicit list of locale identifiers
     # @param markers [Symbol, Array<String>] Data markers (:all or specific markers)
     # @param format [Symbol] Output format (:blob)
     # @param output [Pathname] Output path
@@ -228,11 +233,20 @@ end
 ### Usage
 
 ```ruby
+# Using explicit locale list
 ICU4X::DataGenerator.export(
   locales: %w[ja en],
   markers: :all,
   format: :blob,
   output: Pathname.new("data/i18n.blob")
+)
+
+# Using symbolic locale specifier
+ICU4X::DataGenerator.export(
+  locales: :modern,
+  markers: :all,
+  format: :blob,
+  output: Pathname.new("data/modern.blob")
 )
 ```
 

--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -112,10 +112,18 @@
 #     class DataGenerator
 #       # Exports locale data to a file.
 #       #
-#       # The +und+ (undetermined) locale is automatically included if not specified,
-#       # as it provides essential fallback data for ICU4X operations.
+#       # The +locales+ parameter accepts either a Symbol for predefined locale sets
+#       # based on CLDR coverage levels, or an Array of locale identifier strings.
+#       # When using +with_descendants+, ancestor locales (including +und+) are
+#       # automatically included for fallback support.
 #       #
-#       # @param locales [Array<String>] list of locale identifiers to include
+#       # @param locales [Symbol, Array<String>] locale specification:
+#       #   - +:full+ - all CLDR locales (700+)
+#       #   - +:recommended+ - locales with basic, moderate, or modern coverage (164)
+#       #   - +:modern+ - locales with modern coverage only (103)
+#       #   - +:moderate+ - locales with moderate coverage only
+#       #   - +:basic+ - locales with basic coverage only
+#       #   - +Array<String>+ - explicit list of locale identifiers
 #       # @param markers [Symbol, Array<String>] data markers to include;
 #       #   use +:all+ for all markers, or specify individual marker names
 #       # @param format [Symbol] output format, currently only +:blob+ is supported
@@ -131,7 +139,16 @@
 #       #     output: Pathname.new("i18n_data.postcard")
 #       #   )
 #       #
+#       # @example Export data for all modern coverage locales
+#       #   ICU4X::DataGenerator.export(
+#       #     locales: :modern,
+#       #     markers: :all,
+#       #     format: :blob,
+#       #     output: Pathname.new("modern_data.postcard")
+#       #   )
+#       #
 #       # @see .available_markers
+#       # @see https://cldr.unicode.org/index/cldr-spec/coverage-levels CLDR Coverage Levels
 #       #
 #       def self.export(locales:, markers:, format:, output:); end
 #

--- a/spec/icu4x/data_generator_spec.rb
+++ b/spec/icu4x/data_generator_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe ICU4X::DataGenerator do
     let(:output_dir) { Pathname.new(Dir.mktmpdir) }
     let(:output_path) { output_dir / "test-data.postcard" }
 
-    before do
-      allow(Kernel).to receive(:warn)
-    end
-
     after do
       FileUtils.rm_rf(output_dir)
     end
@@ -27,28 +23,6 @@ RSpec.describe ICU4X::DataGenerator do
 
         expect(output_path).to exist
         expect(output_path.size).to be > 0
-      end
-
-      it "warns when 'und' locale is automatically included", :slow do
-        ICU4X::DataGenerator.export(
-          locales: %w[en],
-          markers: %w[PluralsCardinalV1],
-          format: :blob,
-          output: output_path
-        )
-
-        expect(Kernel).to have_received(:warn).with(/'und' locale automatically included/)
-      end
-
-      it "does not warn when 'und' locale is included", :slow do
-        ICU4X::DataGenerator.export(
-          locales: %w[en und],
-          markers: %w[PluralsCardinalV1],
-          format: :blob,
-          output: output_path
-        )
-
-        expect(Kernel).not_to have_received(:warn)
       end
 
       it "creates a blob that can be loaded by DataProvider", :slow do
@@ -74,6 +48,79 @@ RSpec.describe ICU4X::DataGenerator do
 
         expect(output_path).to exist
         expect(output_path.size).to be > 0
+      end
+    end
+
+    context "with symbolic locale specifiers" do
+      it "accepts :full for all locales", :slow do
+        ICU4X::DataGenerator.export(
+          locales: :full,
+          markers: %w[PluralsCardinalV1],
+          format: :blob,
+          output: output_path
+        )
+
+        expect(output_path).to exist
+        expect(output_path.size).to be > 0
+      end
+
+      it "accepts :modern for modern coverage locales", :slow do
+        ICU4X::DataGenerator.export(
+          locales: :modern,
+          markers: %w[PluralsCardinalV1],
+          format: :blob,
+          output: output_path
+        )
+
+        expect(output_path).to exist
+        expect(output_path.size).to be > 0
+      end
+
+      it "accepts :moderate for moderate coverage locales", :slow do
+        ICU4X::DataGenerator.export(
+          locales: :moderate,
+          markers: %w[PluralsCardinalV1],
+          format: :blob,
+          output: output_path
+        )
+
+        expect(output_path).to exist
+        expect(output_path.size).to be > 0
+      end
+
+      it "accepts :basic for basic coverage locales", :slow do
+        ICU4X::DataGenerator.export(
+          locales: :basic,
+          markers: %w[PluralsCardinalV1],
+          format: :blob,
+          output: output_path
+        )
+
+        expect(output_path).to exist
+        expect(output_path.size).to be > 0
+      end
+
+      it "accepts :recommended for all coverage levels", :slow do
+        ICU4X::DataGenerator.export(
+          locales: :recommended,
+          markers: %w[PluralsCardinalV1],
+          format: :blob,
+          output: output_path
+        )
+
+        expect(output_path).to exist
+        expect(output_path.size).to be > 0
+      end
+
+      it "raises ArgumentError for unknown locale symbol" do
+        expect {
+          ICU4X::DataGenerator.export(
+            locales: :unknown,
+            markers: :all,
+            format: :blob,
+            output: output_path
+          )
+        }.to raise_error(ArgumentError, /unknown locale specifier: :unknown/)
       end
     end
 


### PR DESCRIPTION
## Summary
Add symbolic locale specifiers (`:full`, `:recommended`, `:modern`, `:moderate`, `:basic`) to `DataGenerator.export` based on CLDR coverage levels.

## Changes
- Support Symbol for `locales` parameter based on CLDR coverage levels
- Remove explicit `und` auto-inclusion (handled by `with_descendants`)
- Update YARD docs and doc/data.md with new parameter options

## Test Plan
- Run `bundle exec rspec spec/icu4x/data_generator_spec.rb`
- Verify symbolic specifiers work: `locales: :modern`

Fixes #65
Related to #36
