### PR TITLE
:bug: Fix incorrect example in available_markers docs

### DIFF
--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -158,7 +158,7 @@
 #       #
 #       # @example
 #       #   markers = ICU4X::DataGenerator.available_markers
-#       #   #=> ["datetime/gregory/datelengths@1", "decimal/symbols@1", ...]
+#       #   #=> ["CalendarJapaneseExtendedV1", "CalendarJapaneseModernV1", ...]
 #       #
 #       def self.available_markers; end
 #     end


### PR DESCRIPTION
## Summary
Fix incorrect example output format in `available_markers` YARD documentation.

## Changes
- Update example from old-style marker names (`datetime/gregory/datelengths@1`) to current struct-style names (`CalendarJapaneseExtendedV1`)

Fixes #66
