### PR TITLE
:sparkles: Add Rake task for data generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,22 +30,15 @@ unless ENV["RUBY_TARGET"]
   require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:spec)
 
+  require "icu4x/rake_task"
   TEST_BLOB = "spec/fixtures/test-data.postcard"
-  TEST_BLOB_LOCALES = %w[en ja ru ar de und].freeze
 
-  directory "spec/fixtures"
-
-  file TEST_BLOB => ["spec/fixtures", :compile] do |t|
-    require "icu4x"
-    require "pathname"
-    ICU4X::DataGenerator.export(
-      locales: TEST_BLOB_LOCALES,
-      markers: :all,
-      format: :blob,
-      output: Pathname.new(t.name)
-    )
+  ICU4X::RakeTask.new do |t|
+    t.locales = %w[en ja ru ar de]
+    t.output = TEST_BLOB
   end
 
+  Rake::Task[TEST_BLOB].enhance([:compile])
   Rake::Task[:spec].enhance([TEST_BLOB])
 
   require "yard"

--- a/doc/data.md
+++ b/doc/data.md
@@ -261,6 +261,53 @@ ICU4X::DataGenerator.available_markers
 
 ---
 
+## Rake Task
+
+A Rake task for generating data blobs as part of your build workflow.
+
+### Setup
+
+```ruby
+# Rakefile
+require "icu4x/rake_task"
+
+ICU4X::RakeTask.new do |t|
+  t.output = "data/icu4x.postcard"
+end
+```
+
+### Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `locales` | `:recommended` | Locale specifier or array of locale strings |
+| `markers` | `:all` | Data markers to include |
+| `output` | (required) | Output path relative to Rakefile |
+
+### Task Name
+
+Default task name is `icu4x:data:generate`. Customize by passing a name to the constructor:
+
+```ruby
+ICU4X::RakeTask.new("myapp:generate_data") do |t|
+  t.output = "data/icu4x.postcard"
+end
+```
+
+### Usage
+
+```bash
+rake icu4x:data:generate  # Generate (skips if file exists)
+rake clobber              # Remove generated file
+```
+
+### Behavior
+
+- Implemented as a `file` task: generation is skipped if output file already exists
+- Output file is automatically added to `CLOBBER` for cleanup
+
+---
+
 ## Notes
 
 - No data is bundled with the gem

--- a/lib/icu4x/rake_task.rb
+++ b/lib/icu4x/rake_task.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rake"
+require "rake/clean"
+require "rake/tasklib"
+
+module ICU4X
+  # Rake task for generating ICU4X data blobs.
+  #
+  # @example Basic usage
+  #   require "icu4x/rake_task"
+  #
+  #   ICU4X::RakeTask.new do |t|
+  #     t.output = "data/icu4x.postcard"
+  #   end
+  #
+  # @example Custom task name and locales
+  #   ICU4X::RakeTask.new("myapp:generate_data") do |t|
+  #     t.locales = %w[en ja de]
+  #     t.output = "data/icu4x.postcard"
+  #   end
+  class RakeTask < ::Rake::TaskLib
+    # @return [String] The name of the task
+    attr_reader :name
+
+    # @return [Symbol, Array<String>] Locale specifier or array of locale strings
+    #   Defaults to +:recommended+
+    attr_accessor :locales
+
+    # @return [Symbol, Array<String>] Data markers to include
+    #   Defaults to +:all+
+    attr_accessor :markers
+
+    # @return [Pathname, String] Output path relative to Rakefile
+    attr_accessor :output
+
+    # Creates a new RakeTask.
+    #
+    # @param name [String] Task name (default: "icu4x:data:generate")
+    # @yield [self] Configuration block
+    # @yieldparam task [RakeTask] The task instance for configuration
+    def initialize(name="icu4x:data:generate")
+      super()
+      @name = name
+      @locales = :recommended
+      @markers = :all
+      @output = nil
+
+      yield self if block_given?
+
+      raise ArgumentError, "output is required" if @output.nil?
+
+      define_tasks
+    end
+
+    private def define_tasks
+      output_path = Pathname(@output)
+
+      desc "Generate ICU4X data blob"
+      file output_path.to_s do
+        require "icu4x"
+        output_path.dirname.mkpath
+        ICU4X::DataGenerator.export(
+          locales: @locales,
+          markers: @markers,
+          format: :blob,
+          output: output_path
+        )
+      end
+
+      desc "Generate ICU4X data blob"
+      task @name => output_path.to_s
+
+      CLOBBER.include(output_path.to_s)
+    end
+  end
+end

--- a/spec/icu4x/rake_task_spec.rb
+++ b/spec/icu4x/rake_task_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "icu4x/rake_task"
+require "pathname"
+require "tmpdir"
+
+RSpec.describe ICU4X::RakeTask do
+  let(:output_dir) { Pathname.new(Dir.mktmpdir) }
+  let(:output_path) { output_dir / "test-data.postcard" }
+
+  before do
+    Rake.application = Rake::Application.new
+    CLOBBER.clear
+  end
+
+  after do
+    FileUtils.rm_rf(output_dir)
+  end
+
+  describe "#initialize" do
+    it "creates a task with default name" do
+      ICU4X::RakeTask.new {|t| t.output = output_path }
+
+      expect(Rake::Task.task_defined?("icu4x:data:generate")).to be true
+    end
+
+    it "creates a task with custom name" do
+      ICU4X::RakeTask.new("custom:generate") {|t| t.output = output_path }
+
+      expect(Rake::Task.task_defined?("custom:generate")).to be true
+    end
+
+    it "raises ArgumentError when output is not specified" do
+      expect { ICU4X::RakeTask.new }.to raise_error(ArgumentError, /output is required/)
+    end
+
+    it "has default locales of :recommended" do
+      task = ICU4X::RakeTask.new {|t| t.output = output_path }
+
+      expect(task.locales).to eq(:recommended)
+    end
+
+    it "has default markers of :all" do
+      task = ICU4X::RakeTask.new {|t| t.output = output_path }
+
+      expect(task.markers).to eq(:all)
+    end
+
+    it "allows custom locales" do
+      task = ICU4X::RakeTask.new do |t|
+        t.locales = %w[en ja]
+        t.output = output_path
+      end
+
+      expect(task.locales).to eq(%w[en ja])
+    end
+
+    it "allows custom markers" do
+      task = ICU4X::RakeTask.new do |t|
+        t.markers = %w[PluralsCardinalV1]
+        t.output = output_path
+      end
+
+      expect(task.markers).to eq(%w[PluralsCardinalV1])
+    end
+  end
+
+  describe "file task" do
+    it "creates output file when invoked", :slow do
+      ICU4X::RakeTask.new do |t|
+        t.locales = %w[en]
+        t.markers = %w[PluralsCardinalV1]
+        t.output = output_path
+      end
+
+      Rake::Task["icu4x:data:generate"].invoke
+
+      expect(output_path).to exist
+      expect(output_path.size).to be > 0
+    end
+
+    it "creates parent directories if needed", :slow do
+      nested_path = output_dir / "nested" / "dir" / "data.postcard"
+
+      ICU4X::RakeTask.new do |t|
+        t.locales = %w[en]
+        t.markers = %w[PluralsCardinalV1]
+        t.output = nested_path
+      end
+
+      Rake::Task["icu4x:data:generate"].invoke
+
+      expect(nested_path).to exist
+    end
+
+    it "skips generation if file already exists", :slow do
+      ICU4X::RakeTask.new do |t|
+        t.locales = %w[en]
+        t.markers = %w[PluralsCardinalV1]
+        t.output = output_path
+      end
+
+      Rake::Task["icu4x:data:generate"].invoke
+      original_mtime = output_path.mtime
+
+      sleep 0.1
+      Rake::Task["icu4x:data:generate"].reenable
+      Rake::Task[output_path.to_s].reenable
+      Rake::Task["icu4x:data:generate"].invoke
+
+      expect(output_path.mtime).to eq(original_mtime)
+    end
+  end
+
+  describe "CLOBBER" do
+    it "includes output path in CLOBBER" do
+      ICU4X::RakeTask.new {|t| t.output = output_path }
+
+      expect(CLOBBER).to include(output_path.to_s)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add `ICU4X::RakeTask` for generating data blobs as part of build workflows.

## Changes
- Add `lib/icu4x/rake_task.rb` with configurable locales, markers, and output
- Implement as file task (skips if output exists)
- Add output to CLOBBER for cleanup
- Refactor project Rakefile to use the new RakeTask

## Usage

```ruby
require "icu4x/rake_task"

ICU4X::RakeTask.new do |t|
  t.locales = %w[en ja de]
  t.output = "data/icu4x.postcard"
end
```

```bash
rake icu4x:data:generate  # Generate (skips if exists)
rake clobber              # Remove generated file
```

Fixes #70
