### PR TITLE
:bug: Fix incorrect Segment method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ dn.of("en")
 
 # Text segmentation
 segmenter = ICU4X::Segmenter.new(granularity: :word, provider:)
-segmenter.segment("Hello, world!").map(&:text)
+segmenter.segment("Hello, world!").map(&:segment)
 # => ["Hello", ",", " ", "world", "!"]
 ```
 


### PR DESCRIPTION
## Summary

Fix README.md to use `#segment` instead of `#text` for accessing Segment text.

## Changes

- Use correct method name `#segment` in Segmenter example

Fixes #75
