### PR TITLE
:sparkles: Auto-generate CHANGELOG entries from commit analysis

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -41,16 +41,152 @@ jobs:
         GEM_PATH="${GEM_PATH//-//}"  # Convert hyphens to slashes for path
         sed -i 's/VERSION = ".*"/VERSION = "${{ github.event.inputs.version }}"/' "lib/$GEM_PATH/version.rb"
 
+    - name: Generate CHANGELOG entries
+      env:
+        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      run: |
+        # Get the last release tag
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+        # Get commits since last tag (or all commits if no tag exists)
+        if [ -n "$LAST_TAG" ]; then
+          echo "Analyzing commits since $LAST_TAG"
+          COMMITS=$(git log --format="- %s" "$LAST_TAG"..HEAD)
+        else
+          echo "No previous tag found, analyzing all commits"
+          COMMITS=$(git log --format="- %s")
+        fi
+
+        # Extract existing [Unreleased] section content
+        EXISTING_CHANGELOG=$(awk '
+          /^## \[Unreleased\]/ { found=1; next }
+          /^## \[/ && found { exit }
+          found { print }
+        ' CHANGELOG.md | sed '/^$/d')
+
+        echo "Existing changelog entries:"
+        echo "$EXISTING_CHANGELOG"
+
+        # Skip if no commits to analyze and no existing entries
+        if [ -z "$COMMITS" ] && [ -z "$EXISTING_CHANGELOG" ]; then
+          echo "No commits or existing entries to analyze"
+          echo "(no user-facing changes)" > /tmp/changelog_entries.txt
+          exit 0
+        fi
+
+        echo "Commits to analyze:"
+        echo "$COMMITS"
+
+        # Build the prompt for Claude
+        PROMPT=$(cat <<'PROMPT_EOF'
+        Generate a complete CHANGELOG section by analyzing git commits and existing changelog entries.
+
+        Rules:
+        1. Only include changes that affect end users (features, bug fixes, breaking changes, performance improvements)
+        2. Exclude internal changes (refactoring, tests, CI/CD, documentation unless user-facing)
+        3. Group entries by category: Added, Changed, Fixed, Removed, Deprecated, Security
+        4. Each entry should be a concise description in imperative mood
+        5. If a commit references an issue (e.g., #123, Fixes #123), include it in parentheses at the end
+        6. Merge existing entries with new ones from commits - avoid duplicates
+        7. Preserve existing entries that are still relevant, but may rephrase for consistency
+        8. Output ONLY the markdown content (no explanations), starting with ### if there are entries
+        9. If there are no user-facing changes, output exactly: (no user-facing changes)
+
+        Example output:
+        ### Added
+        - Implement list formatting support (#42)
+
+        ### Fixed
+        - Fix memory leak in data provider (#88)
+
+        PROMPT_EOF
+        )
+
+        # Build the full prompt with existing entries and commits
+        FULL_PROMPT="$PROMPT"
+        if [ -n "$EXISTING_CHANGELOG" ]; then
+          FULL_PROMPT="$FULL_PROMPT
+
+        Existing changelog entries (preserve and merge with commits):
+        $EXISTING_CHANGELOG"
+        fi
+
+        if [ -n "$COMMITS" ]; then
+          FULL_PROMPT="$FULL_PROMPT
+
+        Git commits to analyze:
+        $COMMITS"
+        fi
+
+        # Call Claude API
+        RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
+          -H "Content-Type: application/json" \
+          -H "x-api-key: $ANTHROPIC_API_KEY" \
+          -H "anthropic-version: 2023-06-01" \
+          -d "$(jq -n \
+            --arg prompt "$FULL_PROMPT" \
+            '{
+              model: "claude-sonnet-4-20250514",
+              max_tokens: 1024,
+              messages: [{
+                role: "user",
+                content: $prompt
+              }]
+            }')")
+
+        # Extract the generated changelog entries
+        CHANGELOG_ENTRIES=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
+
+        if [ -z "$CHANGELOG_ENTRIES" ]; then
+          echo "Failed to generate changelog entries"
+          echo "API Response: $RESPONSE"
+          exit 1
+        fi
+
+        echo "Generated CHANGELOG entries:"
+        echo "$CHANGELOG_ENTRIES"
+
+        # Save entries for the next step
+        echo "$CHANGELOG_ENTRIES" > /tmp/changelog_entries.txt
+
     - name: Update CHANGELOG.md
       run: |
         # Get current date in UTC (GitHub Actions runs in UTC timezone)
         RELEASE_DATE=$(date -u +%Y-%m-%d)
+        VERSION="${{ github.event.inputs.version }}"
 
-        # Update changelog
-        sed -i "s/## \[Unreleased\]/## [${{ github.event.inputs.version }}] - $RELEASE_DATE/" CHANGELOG.md
+        # Read generated changelog entries
+        CHANGELOG_ENTRIES=""
+        if [ -f /tmp/changelog_entries.txt ]; then
+          CHANGELOG_ENTRIES=$(cat /tmp/changelog_entries.txt)
+        fi
 
-        # Add new unreleased section
-        sed -i "/## \[${{ github.event.inputs.version }}\]/i## [Unreleased]\n" CHANGELOG.md
+        # Build the new release section
+        if [ "$CHANGELOG_ENTRIES" = "(no user-facing changes)" ] || [ -z "$CHANGELOG_ENTRIES" ]; then
+          NEW_SECTION="## [$VERSION] - $RELEASE_DATE
+
+        No user-facing changes in this release."
+        else
+          NEW_SECTION="## [$VERSION] - $RELEASE_DATE
+
+        $CHANGELOG_ENTRIES"
+        fi
+
+        # Replace [Unreleased] section with new release section and add new [Unreleased]
+        awk -v new_section="$NEW_SECTION" '
+          /^## \[Unreleased\]/ {
+            print "## [Unreleased]"
+            print ""
+            print new_section
+            skip = 1
+            next
+          }
+          /^## \[/ && skip {
+            skip = 0
+          }
+          !skip { print }
+        ' CHANGELOG.md > /tmp/changelog_new.md
+        mv /tmp/changelog_new.md CHANGELOG.md
 
     - name: Commit changes
       run: |


### PR DESCRIPTION
## Summary

Add Claude API integration to automatically generate CHANGELOG entries during release preparation.

## Changes

- Add "Generate CHANGELOG entries" step that:
  - Gets commits since last release tag
  - Extracts existing `[Unreleased]` section content
  - Sends both to Claude API for analysis and merging
  - Generates categorized entries with issue references

- Update "Update CHANGELOG.md" step to:
  - Insert generated entries into the release section
  - Handle case when no user-facing changes exist

## How It Works

1. On release preparation, workflow fetches commits since last tag
2. Existing partial changelog entries are extracted from `[Unreleased]`
3. Claude analyzes both and generates a merged, deduplicated changelog
4. Entries are categorized (Added, Changed, Fixed, etc.) with issue refs

Fixes #90
