### PR TITLE
:memo: Expand unsafe impl Send safety documentation

### DIFF
--- a/ext/icu4x/src/collator.rs
+++ b/ext/icu4x/src/collator.rs
@@ -46,7 +46,18 @@ pub struct Collator {
     case_first: Option<CaseFirstOption>,
 }
 
-// SAFETY: Ruby's GVL protects access to this type.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for Collator {}
 
 impl Collator {

--- a/ext/icu4x/src/data_provider.rs
+++ b/ext/icu4x/src/data_provider.rs
@@ -25,8 +25,18 @@ pub struct DataProvider {
     pub(crate) inner: LocaleFallbackProvider<BlobDataProvider>,
 }
 
-// SAFETY: Ruby's GVL protects access to this type. The provider is only
-// accessed through Ruby method calls, which are serialized by the GVL.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for DataProvider {}
 
 impl DataProvider {

--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -106,7 +106,18 @@ pub struct DateTimeFormat {
     calendar: Calendar,
 }
 
-// SAFETY: Ruby's GVL protects access to this type.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for DateTimeFormat {}
 
 impl DateTimeFormat {

--- a/ext/icu4x/src/display_names.rs
+++ b/ext/icu4x/src/display_names.rs
@@ -72,7 +72,18 @@ pub struct DisplayNames {
     fallback: DisplayNamesFallback,
 }
 
-// SAFETY: Ruby's GVL protects access to this type.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for DisplayNames {}
 
 impl DisplayNames {

--- a/ext/icu4x/src/list_format.rs
+++ b/ext/icu4x/src/list_format.rs
@@ -43,7 +43,18 @@ pub struct ListFormat {
     list_style: ListStyle,
 }
 
-// SAFETY: Ruby's GVL protects access to this type.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for ListFormat {}
 
 impl ListFormat {

--- a/ext/icu4x/src/number_format.rs
+++ b/ext/icu4x/src/number_format.rs
@@ -83,7 +83,18 @@ pub struct NumberFormat {
     rounding_mode: RoundingMode,
 }
 
-// SAFETY: Ruby's GVL protects access to this type.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for NumberFormat {}
 
 impl NumberFormat {

--- a/ext/icu4x/src/plural_rules.rs
+++ b/ext/icu4x/src/plural_rules.rs
@@ -17,7 +17,18 @@ pub struct PluralRules {
     rule_type: PluralRuleType,
 }
 
-// SAFETY: Ruby's GVL protects access to this type.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for PluralRules {}
 
 impl PluralRules {

--- a/ext/icu4x/src/relative_time_format.rs
+++ b/ext/icu4x/src/relative_time_format.rs
@@ -75,7 +75,18 @@ pub struct RelativeTimeFormat {
     numeric: NumericMode,
 }
 
-// SAFETY: Ruby's GVL protects access to this type.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for RelativeTimeFormat {}
 
 impl RelativeTimeFormat {

--- a/ext/icu4x/src/segmenter.rs
+++ b/ext/icu4x/src/segmenter.rs
@@ -38,7 +38,18 @@ pub struct Segmenter {
     granularity: Granularity,
 }
 
-// SAFETY: Ruby's GVL protects access to this type.
+// SAFETY: This type is marked as Send to allow Ruby to move it between threads.
+//
+// Thread safety is guaranteed by Ruby's Global VM Lock (GVL):
+// - All Ruby method calls are serialized by the GVL
+// - Only one thread can execute Ruby code at a time
+// - The underlying ICU4X types are only accessed through Ruby method calls
+//
+// WARNING: This safety guarantee does NOT hold if:
+// - The GVL is released via `rb_thread_call_without_gvl`
+// - Using threading libraries that bypass the GVL
+//
+// In such cases, concurrent access to this type would be unsafe.
 unsafe impl Send for Segmenter {}
 
 impl Segmenter {


### PR DESCRIPTION
## Summary

Expand and standardize `unsafe impl Send` safety documentation across all 9 wrapper types.

## Changes

- Standardize safety comments with consistent format
- Document GVL protection mechanism
- Add warnings about scenarios where safety guarantees don't hold (GVL bypass)

Closes #84
