### PR TITLE
:sparkles: Add maximize/minimize methods to ICU4X::Locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+- `ICU4X::Locale#maximize!` and `#maximize` methods to expand locale using Likely Subtags algorithm (UTS #35)
+- `ICU4X::Locale#minimize!` and `#minimize` methods to remove redundant subtags
+
 ## [0.7.0] - 2026-01-09
 
 ### Added

--- a/doc/locale.md
+++ b/doc/locale.md
@@ -71,6 +71,22 @@ module ICU4X
     # Hash code
     # @return [Integer]
     def hash = ...
+
+    # Maximize locale in place (Add Likely Subtags algorithm, UTS #35)
+    # @return [self, nil] self if modified, nil if unchanged
+    def maximize! = ...
+
+    # Return a new maximized locale
+    # @return [Locale] new locale with likely subtags added
+    def maximize = ...
+
+    # Minimize locale in place (Remove Likely Subtags algorithm, UTS #35)
+    # @return [self, nil] self if modified, nil if unchanged
+    def minimize! = ...
+
+    # Return a new minimized locale
+    # @return [Locale] new locale with redundant subtags removed
+    def minimize = ...
   end
 end
 ```
@@ -105,6 +121,28 @@ loc5.to_s      # => "und"
 # Locales can be used as Hash keys
 cache = {}
 cache[loc] = "cached value"
+
+# Maximize: add likely subtags
+loc6 = ICU4X::Locale.parse("en")
+loc6.maximize!     # => loc6 (self)
+loc6.to_s          # => "en-Latn-US"
+
+# Non-destructive maximize
+loc7 = ICU4X::Locale.parse("zh")
+expanded = loc7.maximize
+loc7.to_s          # => "zh" (unchanged)
+expanded.to_s      # => "zh-Hans-CN"
+
+# Minimize: remove redundant subtags
+loc8 = ICU4X::Locale.parse("ja-Jpan-JP")
+loc8.minimize!     # => loc8 (self)
+loc8.to_s          # => "ja"
+
+# Non-destructive minimize
+loc9 = ICU4X::Locale.parse("en-Latn-US")
+minimal = loc9.minimize
+loc9.to_s          # => "en-Latn-US" (unchanged)
+minimal.to_s       # => "en"
 ```
 
 ---

--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -274,6 +274,74 @@
 #       # @return [Integer] hash code
 #       #
 #       def hash; end
+#
+#       # Maximizes the locale in place using the Add Likely Subtags algorithm (UTS #35).
+#       #
+#       # Adds likely script and region subtags based on the language.
+#       # This is useful for language negotiation.
+#       #
+#       # @return [self, nil] self if the locale was modified, nil if already maximized
+#       #
+#       # @example
+#       #   locale = ICU4X::Locale.parse("en")
+#       #   locale.maximize!  #=> locale
+#       #   locale.to_s       #=> "en-Latn-US"
+#       #
+#       # @example Already maximized
+#       #   locale = ICU4X::Locale.parse("en-Latn-US")
+#       #   locale.maximize!  #=> nil
+#       #
+#       # @see https://unicode.org/reports/tr35/#Likely_Subtags
+#       #
+#       def maximize!; end
+#
+#       # Returns a new locale with likely subtags added.
+#       #
+#       # Non-destructive version of {#maximize!}. The original locale is unchanged.
+#       #
+#       # @return [Locale] a new locale with likely subtags added
+#       #
+#       # @example
+#       #   locale = ICU4X::Locale.parse("zh")
+#       #   expanded = locale.maximize
+#       #   locale.to_s    #=> "zh" (unchanged)
+#       #   expanded.to_s  #=> "zh-Hans-CN"
+#       #
+#       def maximize; end
+#
+#       # Minimizes the locale in place using the Remove Likely Subtags algorithm (UTS #35).
+#       #
+#       # Removes redundant script and region subtags that can be inferred.
+#       # This is useful for language negotiation.
+#       #
+#       # @return [self, nil] self if the locale was modified, nil if already minimal
+#       #
+#       # @example
+#       #   locale = ICU4X::Locale.parse("ja-Jpan-JP")
+#       #   locale.minimize!  #=> locale
+#       #   locale.to_s       #=> "ja"
+#       #
+#       # @example Already minimal
+#       #   locale = ICU4X::Locale.parse("en")
+#       #   locale.minimize!  #=> nil
+#       #
+#       # @see https://unicode.org/reports/tr35/#Likely_Subtags
+#       #
+#       def minimize!; end
+#
+#       # Returns a new locale with redundant subtags removed.
+#       #
+#       # Non-destructive version of {#minimize!}. The original locale is unchanged.
+#       #
+#       # @return [Locale] a new locale with redundant subtags removed
+#       #
+#       # @example
+#       #   locale = ICU4X::Locale.parse("zh-Hans-CN")
+#       #   minimal = locale.minimize
+#       #   locale.to_s   #=> "zh-Hans-CN" (unchanged)
+#       #   minimal.to_s  #=> "zh"
+#       #
+#       def minimize; end
 #     end
 #
 #     # Provides locale-aware plural rules for cardinal and ordinal numbers.

--- a/spec/icu4x/locale_spec.rb
+++ b/spec/icu4x/locale_spec.rb
@@ -186,4 +186,109 @@ RSpec.describe ICU4X::Locale do
       expect { ICU4X::Locale.parse_posix("") }.to raise_error(ICU4X::LocaleError)
     end
   end
+
+  describe "#maximize!" do
+    it "expands language to full locale and returns self" do
+      locale = ICU4X::Locale.parse("en")
+
+      expect(locale.maximize!).to be(locale)
+      expect(locale.to_s).to eq("en-Latn-US")
+    end
+
+    it "expands zh to zh-Hans-CN" do
+      locale = ICU4X::Locale.parse("zh")
+
+      expect(locale.maximize!).to be(locale)
+      expect(locale.to_s).to eq("zh-Hans-CN")
+    end
+
+    it "expands ja to ja-Jpan-JP" do
+      locale = ICU4X::Locale.parse("ja")
+
+      expect(locale.maximize!).to be(locale)
+      expect(locale.to_s).to eq("ja-Jpan-JP")
+    end
+
+    it "returns nil when already maximized" do
+      locale = ICU4X::Locale.parse("en-Latn-US")
+
+      expect(locale.maximize!).to be_nil
+      expect(locale.to_s).to eq("en-Latn-US")
+    end
+
+    it "handles script inference" do
+      locale = ICU4X::Locale.parse("sr-Latn")
+
+      locale.maximize!
+
+      expect(locale.region).to eq("RS")
+    end
+  end
+
+  describe "#maximize" do
+    it "returns a new maximized locale" do
+      locale = ICU4X::Locale.parse("en")
+
+      result = locale.maximize
+
+      expect(result).not_to be(locale)
+      expect(result.to_s).to eq("en-Latn-US")
+      expect(locale.to_s).to eq("en")
+    end
+
+    it "returns a new object even when already maximized" do
+      locale = ICU4X::Locale.parse("en-Latn-US")
+
+      result = locale.maximize
+
+      expect(result).not_to be(locale)
+      expect(result.to_s).to eq("en-Latn-US")
+    end
+  end
+
+  describe "#minimize!" do
+    it "removes redundant subtags and returns self" do
+      locale = ICU4X::Locale.parse("zh-Hans-CN")
+
+      expect(locale.minimize!).to be(locale)
+      expect(locale.to_s).to eq("zh")
+    end
+
+    it "keeps necessary subtags" do
+      # sr-Latn needs script since sr defaults to Cyrillic
+      locale = ICU4X::Locale.parse("sr-Latn")
+
+      locale.minimize!
+
+      expect(locale.script).to eq("Latn")
+    end
+
+    it "returns nil when already minimal" do
+      locale = ICU4X::Locale.parse("en")
+
+      expect(locale.minimize!).to be_nil
+      expect(locale.to_s).to eq("en")
+    end
+  end
+
+  describe "#minimize" do
+    it "returns a new minimized locale" do
+      locale = ICU4X::Locale.parse("zh-Hans-CN")
+
+      result = locale.minimize
+
+      expect(result).not_to be(locale)
+      expect(result.to_s).to eq("zh")
+      expect(locale.to_s).to eq("zh-Hans-CN")
+    end
+
+    it "returns a new object even when already minimal" do
+      locale = ICU4X::Locale.parse("en")
+
+      result = locale.minimize
+
+      expect(result).not_to be(locale)
+      expect(result.to_s).to eq("en")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Add `maximize`/`maximize!` and `minimize`/`minimize!` methods to `ICU4X::Locale` for Likely Subtags algorithm (UTS #35) support.

## Changes

- Implement `maximize!` and `maximize` methods to add likely script/region subtags
- Implement `minimize!` and `minimize` methods to remove redundant subtags
- Follow Ruby conventions: `!` methods return `self` if modified, `nil` otherwise
- Add comprehensive RSpec tests and documentation

## Examples

```ruby
# Maximize: add likely subtags
locale = ICU4X::Locale.parse("en")
locale.maximize!  # => locale
locale.to_s       # => "en-Latn-US"

# Minimize: remove redundant subtags
locale = ICU4X::Locale.parse("ja-Jpan-JP")
locale.minimize!  # => locale
locale.to_s       # => "ja"
```

Fixes #98
