### PR TITLE
:sparkles: Add Ruby 4.0 prebuilt binary support

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -54,7 +54,7 @@ jobs:
       id: cross-gem
       with:
         platform: ${{ matrix.platform }}
-        ruby-versions: "3.2,3.3,3.4"
+        ruby-versions: "3.2,3.3,3.4,4.0"
 
     - name: Upload cross-compiled gem
       uses: actions/upload-artifact@v4

--- a/icu4x.gemspec
+++ b/icu4x.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |spec|
   spec.extensions = ["ext/icu4x/extconf.rb"]
 
   spec.add_dependency "dry-configurable", "~> 1.3"
-  spec.add_dependency "rb_sys", "~> 0.9"
+  spec.add_dependency "rb_sys", "~> 0.9", ">= 0.9.124"
 end


### PR DESCRIPTION
## Summary

Add Ruby 4.0 prebuilt binary support by updating rb_sys dependency and release workflow.

## Changes

- Require rb_sys >= 0.9.124 for Ruby 4.0 build support
- Add Ruby 4.0 to release workflow ruby-versions

Closes #101
