### PR TITLE
:recycle: Rename Locale.parse to parse_bcp47 with alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `ICU4X::PluralRules#select_range` method for plural category selection on number ranges (#106)
 - Allow data gems to be required by gem name (#104)
+- `ICU4X::Locale.parse_bcp47` method for explicit BCP 47 parsing; `parse` is now an alias (#108)
 
 ## [0.8.1] - 2026-01-12
 

--- a/doc/locale.md
+++ b/doc/locale.md
@@ -26,11 +26,14 @@ A class representing locale identifiers. Supports BCP 47 format.
 ```ruby
 module ICU4X
   class Locale
-    # Parse a locale string
+    # Parse a BCP 47 locale string
     # @param locale_str [String] Locale string in BCP 47 format
     # @return [Locale]
     # @raise [LocaleError] If the format is invalid
-    def self.parse(locale_str) = ...
+    def self.parse_bcp47(locale_str) = ...
+
+    # Alias for parse_bcp47
+    alias parse parse_bcp47
 
     # Parse a POSIX locale string
     # @param posix_str [String] Locale string in POSIX format (e.g., "ja_JP.UTF-8")
@@ -94,7 +97,9 @@ end
 ### Usage Examples
 
 ```ruby
-# Parse BCP 47 format
+# Parse BCP 47 format (parse_bcp47 or its alias parse)
+loc = ICU4X::Locale.parse_bcp47("ja-JP")
+# or
 loc = ICU4X::Locale.parse("ja-JP")
 loc.language  # => "ja"
 loc.region    # => "JP"

--- a/ext/icu4x/src/locale.rs
+++ b/ext/icu4x/src/locale.rs
@@ -11,7 +11,7 @@ pub struct Locale {
 
 impl Locale {
     /// Parse a BCP 47 locale string
-    fn parse(ruby: &Ruby, s: String) -> Result<Self, Error> {
+    fn parse_bcp47(ruby: &Ruby, s: String) -> Result<Self, Error> {
         let locale: IcuLocale = s.parse().map_err(|e| {
             Error::new(
                 helpers::get_exception_class(ruby, "ICU4X::LocaleError"),
@@ -32,7 +32,7 @@ impl Locale {
     fn parse_posix(ruby: &Ruby, posix_str: String) -> Result<Self, Error> {
         // Handle special cases
         if posix_str == "C" || posix_str == "POSIX" {
-            return Self::parse(ruby, "und".to_string());
+            return Self::parse_bcp47(ruby, "und".to_string());
         }
 
         // Handle empty string
@@ -90,7 +90,7 @@ impl Locale {
             bcp47.push_str(&t.to_uppercase());
         }
 
-        Self::parse(ruby, bcp47)
+        Self::parse_bcp47(ruby, bcp47)
     }
 
     /// Get the language component
@@ -208,7 +208,8 @@ impl Locale {
 
 pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     let class = module.define_class("Locale", ruby.class_object())?;
-    class.define_singleton_method("parse", function!(Locale::parse, 1))?;
+    class.define_singleton_method("parse_bcp47", function!(Locale::parse_bcp47, 1))?;
+    class.singleton_class()?.define_alias("parse", "parse_bcp47")?;
     class.define_singleton_method("parse_posix", function!(Locale::parse_posix, 1))?;
     class.define_method("language", method!(Locale::language, 0))?;
     class.define_method("script", method!(Locale::script, 0))?;

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -28,7 +28,8 @@ module ICU4X
   end
 
   class Locale
-    def self.parse: (String locale_str) -> Locale
+    def self.parse_bcp47: (String locale_str) -> Locale
+    alias self.parse self.parse_bcp47
     def self.parse_posix: (String posix_str) -> Locale
 
     def language: () -> String?

--- a/spec/icu4x/locale_spec.rb
+++ b/spec/icu4x/locale_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe ICU4X::Locale do
-  describe ".parse" do
+  describe ".parse_bcp47" do
     it "parses a simple language code" do
-      locale = ICU4X::Locale.parse("en")
+      locale = ICU4X::Locale.parse_bcp47("en")
 
       expect(locale.language).to eq("en")
       expect(locale.script).to be_nil
@@ -11,7 +11,7 @@ RSpec.describe ICU4X::Locale do
     end
 
     it "parses language-region format" do
-      locale = ICU4X::Locale.parse("ja-JP")
+      locale = ICU4X::Locale.parse_bcp47("ja-JP")
 
       expect(locale.language).to eq("ja")
       expect(locale.region).to eq("JP")
@@ -19,7 +19,7 @@ RSpec.describe ICU4X::Locale do
     end
 
     it "parses language-script-region format" do
-      locale = ICU4X::Locale.parse("zh-Hans-CN")
+      locale = ICU4X::Locale.parse_bcp47("zh-Hans-CN")
 
       expect(locale.language).to eq("zh")
       expect(locale.script).to eq("Hans")
@@ -27,7 +27,20 @@ RSpec.describe ICU4X::Locale do
     end
 
     it "raises LocaleError for invalid locale string" do
-      expect { ICU4X::Locale.parse("!!!invalid") }.to raise_error(ICU4X::LocaleError, /Invalid locale/)
+      expect { ICU4X::Locale.parse_bcp47("!!!invalid") }.to raise_error(ICU4X::LocaleError, /Invalid locale/)
+    end
+  end
+
+  describe ".parse" do
+    it "is an alias for .parse_bcp47" do
+      expect(ICU4X::Locale.method(:parse).original_name).to eq(:parse_bcp47)
+    end
+
+    it "parses BCP 47 locale string" do
+      locale = ICU4X::Locale.parse("ja-JP")
+
+      expect(locale.language).to eq("ja")
+      expect(locale.region).to eq("JP")
     end
   end
 


### PR DESCRIPTION
## Summary

Rename `Locale.parse` to `parse_bcp47` for symmetry with `parse_posix`, keeping `parse` as a convenient alias.

## Changes

- Rename `parse` to `parse_bcp47` in Rust extension
- Add `parse` as alias using Magnus `define_alias`
- Update RBS type definitions
- Update documentation and tests

## Before

```ruby
ICU4X::Locale.parse("ja-JP")        # BCP 47
ICU4X::Locale.parse_posix("ja_JP")  # POSIX
```

## After

```ruby
ICU4X::Locale.parse_bcp47("ja-JP")  # BCP 47 (primary)
ICU4X::Locale.parse("ja-JP")        # BCP 47 (alias)
ICU4X::Locale.parse_posix("ja_JP")  # POSIX
```

Closes #108
