### PR TITLE
:sparkles: Add FormattedPart data class

### DIFF
--- a/lib/icu4x.rb
+++ b/lib/icu4x.rb
@@ -54,6 +54,28 @@ module ICU4X
   class DataGeneratorError < Error; end
 end
 
+# Define FormattedPart data class for format_to_parts methods
+module ICU4X
+  FormattedPart = Data.define(:type, :value)
+end
+
+# Enhance the FormattedPart data class
+module ICU4X
+  # Represents a part of a formatted string.
+  #
+  # Used by format_to_parts methods in DateTimeFormat, NumberFormat,
+  # ListFormat, and RelativeTimeFormat.
+  #
+  # @!attribute [r] type
+  #   @return [Symbol] The part type (e.g., :integer, :literal, :year)
+  # @!attribute [r] value
+  #   @return [String] The formatted value
+  class FormattedPart
+    # @return [String] Human-readable representation
+    def inspect = "#<ICU4X::FormattedPart type=#{type.inspect} value=#{value.inspect}>"
+  end
+end
+
 # Define Segment data class for Segmenter
 module ICU4X
   class Segmenter

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -18,6 +18,14 @@ module ICU4X
   class DataGeneratorError < Error
   end
 
+  class FormattedPart
+    attr_reader type: Symbol
+    attr_reader value: String
+
+    def self.[]: (Symbol type, String value) -> FormattedPart
+    def self.new: (type: Symbol, value: String) -> FormattedPart
+  end
+
   class DataProvider
     def self.from_blob: (Pathname path, ?priority: :language | :region) -> DataProvider
   end

--- a/spec/icu4x/formatted_part_spec.rb
+++ b/spec/icu4x/formatted_part_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe ICU4X::FormattedPart do
+  it "inherits from Data" do
+    expect(ICU4X::FormattedPart).to be < Data
+  end
+
+  it "has type and value members" do
+    expect(ICU4X::FormattedPart.members).to eq(%i[type value])
+  end
+
+  describe "#inspect" do
+    it "returns a human-readable representation" do
+      part = ICU4X::FormattedPart[:integer, "123"]
+
+      expect(part.inspect).to eq('#<ICU4X::FormattedPart type=:integer value="123">')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add `FormattedPart` data class for use by all formatter `format_to_parts` methods.

## Changes

- Define `FormattedPart = Data.define(:type, :value)`
- Add custom `#inspect` method
- Add RBS type definition
- Add tests

## Usage

```ruby
ICU4X::FormattedPart[:integer, "123"]
ICU4X::FormattedPart[:literal, ", "]

part = ICU4X::FormattedPart[:year, "2026"]
part.type   # => :year
part.value  # => "2026"
```

Part of #110
Closes #113
