### PR TITLE
:sparkles: Add format_to_parts method to NumberFormat

### DIFF
--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -84,6 +84,7 @@ module ICU4X
     ) -> NumberFormat
 
     def format: (Integer | Float | BigDecimal number) -> String
+    def format_to_parts: (Integer | Float | BigDecimal number) -> Array[FormattedPart]
     def resolved_options: () -> {
       locale: String,
       style: number_format_style,


### PR DESCRIPTION
## Summary
Add `format_to_parts` method to NumberFormat that returns an array of FormattedPart objects.

## Changes
- Add `PartsCollector` struct for collecting formatted parts
- Implement `format_to_parts` method returning `Array[FormattedPart]`
- Update RBS type definitions
- Add pending tests for percent/currency style limitations

## Part Types
`:integer`, `:fraction`, `:decimal`, `:group`, `:minus_sign`, `:plus_sign`, `:literal`

## Limitations
Percent and currency styles currently return a single literal part due to ICU4X experimental formatter not providing part annotations.

Closes #115
