### PR TITLE
:sparkles: Add format_to_parts method to ListFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `ICU4X::ListFormat#format_to_parts` method for breaking down formatted output into typed parts (#116)
 - `ICU4X::DateTimeFormat#format_to_parts` method for breaking down formatted output into typed parts (#114)
 - `ICU4X::NumberFormat#format_to_parts` method for breaking down formatted output into typed parts (#115)
 - `ICU4X::FormattedPart` data class for representing formatted parts (#113)

--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -682,6 +682,29 @@
 #       #
 #       def format(list); end
 #
+#       # Formats a list of strings and returns an array of parts.
+#       #
+#       # Each part contains a type and value, allowing for custom styling
+#       # or processing of individual components.
+#       #
+#       # @param list [Array<String>] the list items to format
+#       # @return [Array<FormattedPart>] array of formatted parts
+#       #
+#       # @example
+#       #   parts = formatter.format_to_parts(["Apple", "Banana", "Cherry"])
+#       #   # => [
+#       #   #   #<ICU4X::FormattedPart type=:element value="Apple">,
+#       #   #   #<ICU4X::FormattedPart type=:literal value=", ">,
+#       #   #   #<ICU4X::FormattedPart type=:element value="Banana">,
+#       #   #   #<ICU4X::FormattedPart type=:literal value=", and ">,
+#       #   #   #<ICU4X::FormattedPart type=:element value="Cherry">
+#       #   # ]
+#       #
+#       # @example Reconstruct the formatted string
+#       #   parts.map(&:value).join  #=> "Apple, Banana, and Cherry"
+#       #
+#       def format_to_parts(list); end
+#
 #       # Returns the resolved options for this instance.
 #       #
 #       # @return [Hash] options hash with keys:

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -153,6 +153,7 @@ module ICU4X
     ) -> ListFormat
 
     def format: (Array[String] list) -> String
+    def format_to_parts: (Array[String] list) -> Array[FormattedPart]
     def resolved_options: () -> {
       locale: String,
       type: list_format_type,


### PR DESCRIPTION
## Summary

Add `format_to_parts` method to `ListFormat` that returns an array of `FormattedPart` objects with `:element` and `:literal` types.

## Changes

- Implement `format_to_parts` in Rust extension using shared `PartsCollector`
- Add `prepare_list` helper method for common list processing
- Add RBS type definition
- Add YARD documentation
- Add comprehensive tests

## Example

```ruby
lf = ICU4X::ListFormat.new(locale, provider:)
parts = lf.format_to_parts(["Apple", "Banana", "Cherry"])
# => [
#   FormattedPart[:element, "Apple"],
#   FormattedPart[:literal, ", "],
#   FormattedPart[:element, "Banana"],
#   FormattedPart[:literal, ", and "],
#   FormattedPart[:element, "Cherry"]
# ]
```

Closes #116
