### PR TITLE
:sparkles: Add format_to_parts method to RelativeTimeFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `ICU4X::RelativeTimeFormat#format_to_parts` method for breaking down formatted output into typed parts (#117)
 - `ICU4X::ListFormat#format_to_parts` method for breaking down formatted output into typed parts (#116)
 - `ICU4X::DateTimeFormat#format_to_parts` method for breaking down formatted output into typed parts (#114)
 - `ICU4X::NumberFormat#format_to_parts` method for breaking down formatted output into typed parts (#115)

--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -639,6 +639,26 @@
 #       #
 #       def format(value, unit); end
 #
+#       # Formats a relative time value and returns an array of parts.
+#       #
+#       # @param value [Integer] the relative time value (negative for past, positive for future)
+#       # @param unit [Symbol] time unit: `:second`, `:minute`, `:hour`, `:day`,
+#       #   `:week`, `:month`, `:quarter`, or `:year`
+#       # @return [Array<FormattedPart>] array of formatted parts
+#       #
+#       # @note The current ICU4X experimental RelativeTimeFormatter does not
+#       #   provide separate part annotations for the numeric value. The entire
+#       #   formatted string is returned as a single `:literal` part.
+#       #
+#       # @example
+#       #   parts = formatter.format_to_parts(-3, :day)
+#       #   # => [#<ICU4X::FormattedPart type=:literal value="3 days ago">]
+#       #
+#       # @example Reconstruct the formatted string
+#       #   parts.map(&:value).join  #=> "3 days ago"
+#       #
+#       def format_to_parts(value, unit); end
+#
 #       # Returns the resolved options for this instance.
 #       #
 #       # @return [Hash] options hash with keys:

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -131,6 +131,7 @@ module ICU4X
     ) -> RelativeTimeFormat
 
     def format: (Integer value, relative_time_unit unit) -> String
+    def format_to_parts: (Integer value, relative_time_unit unit) -> Array[FormattedPart]
     def resolved_options: () -> {
       locale: String,
       style: relative_time_format_style,


### PR DESCRIPTION
## Summary

Add `format_to_parts` method to `RelativeTimeFormat` that returns an array of `FormattedPart` objects.

## Limitations

The current ICU4X experimental `RelativeTimeFormatter` does not provide separate part annotations for the numeric value. The entire formatted string is returned as a single `:literal` part.

## Changes

- Implement `format_to_parts` in Rust extension using shared `PartsCollector`
- Add `prepare_value` helper method for common value processing
- Add RBS type definition
- Add YARD documentation with limitation note
- Add comprehensive tests

## Example

```ruby
rtf = ICU4X::RelativeTimeFormat.new(locale, provider:)
rtf.format_to_parts(-3, :day)
# => [FormattedPart[:literal, "3 days ago"]]

# With numeric: :auto
rtf = ICU4X::RelativeTimeFormat.new(locale, provider:, numeric: :auto)
rtf.format_to_parts(-1, :day)
# => [FormattedPart[:literal, "yesterday"]]
```

Closes #117
