### PR TITLE
:sparkles: Add hour_cycle option to DateTimeFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `hour_cycle` option for `ICU4X::DateTimeFormat` to control 12/24-hour time display (#112)
 - `ICU4X::RelativeTimeFormat#format_to_parts` method for breaking down formatted output into typed parts (#117)
 - `ICU4X::ListFormat#format_to_parts` method for breaking down formatted output into typed parts (#116)
 - `ICU4X::NumberFormat#format_to_parts` method for breaking down formatted output into typed parts (#115)

--- a/doc/datetime_format.md
+++ b/doc/datetime_format.md
@@ -29,8 +29,9 @@ module ICU4X
     # @param time_style [Symbol, nil] :full, :long, :medium, :short
     # @param time_zone [String, nil] IANA timezone name (e.g., "Asia/Tokyo")
     # @param calendar [Symbol] :gregory, :japanese, :buddhist, :chinese, :hebrew, :islamic, :persian, :indian, :ethiopian, :coptic, :roc, :dangi
+    # @param hour_cycle [Symbol, nil] :h11 (0-11), :h12 (1-12), :h23 (0-23)
     # @raise [Error] If options are invalid
-    def initialize(locale, provider:, date_style: nil, time_style: nil, time_zone: nil, calendar: nil) = ...
+    def initialize(locale, provider:, date_style: nil, time_style: nil, time_zone: nil, calendar: nil, hour_cycle: nil) = ...
 
     # Format a time
     # @param time [Time, #to_time] Time to format (or any object responding to #to_time)
@@ -97,6 +98,28 @@ Specify the calendar system to use for formatting.
 | `:dangi` | Korean traditional calendar |
 
 If not specified, defaults based on locale preferences.
+
+#### hour_cycle
+
+Control 12-hour vs 24-hour time display format.
+
+| Value | Range | Midnight | Noon | Usage |
+|-------|-------|----------|------|-------|
+| `:h12` | 1-12 | 12:00 AM | 12:00 PM | US, etc. |
+| `:h11` | 0-11 | 0:00 AM | 0:00 PM | Some Japanese systems |
+| `:h23` | 0-23 | 00:00 | 12:00 | Europe, Japan, etc. |
+
+NOTE: `:h24` (1-24) is not supported as ICU4X does not implement this hour cycle.
+
+```ruby
+dtf = ICU4X::DateTimeFormat.new(
+  locale,
+  provider: provider,
+  time_style: :short,
+  hour_cycle: :h23
+)
+dtf.format(Time.utc(2025, 1, 1, 0, 30))  # => "00:30:00"
+```
 
 ---
 

--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -545,14 +545,19 @@
 #       # @param time_style [Symbol, nil] time format style: `:full`, `:long`, `:medium`, or `:short`
 #       # @param time_zone [String, nil] IANA time zone identifier (e.g., "America/New_York")
 #       # @param calendar [Symbol] calendar system to use
+#       # @param hour_cycle [Symbol, nil] hour cycle: `:h11` (0-11), `:h12` (1-12), or `:h23` (0-23)
 #       # @return [DateTimeFormat] a new instance
 #       # @raise [DataError] if data for the locale is unavailable
 #       #
-#       # @example
+#       # @example Basic usage
 #       #   formatter = ICU4X::DateTimeFormat.new(locale, date_style: :long, time_style: :short)
 #       #
+#       # @example With 24-hour format
+#       #   formatter = ICU4X::DateTimeFormat.new(locale, time_style: :short, hour_cycle: :h23)
+#       #   formatter.format(Time.utc(2025, 1, 1, 0, 30))  #=> "00:30:00"
+#       #
 #       def initialize(locale, provider: nil, date_style: nil, time_style: nil,
-#                      time_zone: nil, calendar: :gregory); end
+#                      time_zone: nil, calendar: :gregory, hour_cycle: nil); end
 #
 #       # Formats a time value according to the configured options.
 #       #
@@ -598,6 +603,7 @@
 #       #   - `:date_style` [Symbol] the date style (if set)
 #       #   - `:time_style` [Symbol] the time style (if set)
 #       #   - `:time_zone` [String] the time zone (if set)
+#       #   - `:hour_cycle` [Symbol] the hour cycle (if set)
 #       #
 #       def resolved_options; end
 #     end

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -69,6 +69,7 @@ module ICU4X
   type date_style = :full | :long | :medium | :short
   type time_style = :full | :long | :medium | :short
   type datetime_calendar = :gregory | :japanese | :buddhist | :chinese | :hebrew | :islamic | :persian | :indian | :ethiopian | :coptic | :roc | :dangi
+  type hour_cycle = :h11 | :h12 | :h23
 
   class NumberFormat
     def self.new: (
@@ -104,7 +105,8 @@ module ICU4X
       ?date_style: date_style,
       ?time_style: time_style,
       ?time_zone: String,
-      ?calendar: datetime_calendar
+      ?calendar: datetime_calendar,
+      ?hour_cycle: hour_cycle
     ) -> DateTimeFormat
 
     def format: (Time time) -> String
@@ -114,7 +116,8 @@ module ICU4X
       calendar: datetime_calendar,
       ?date_style: date_style,
       ?time_style: time_style,
-      ?time_zone: String
+      ?time_zone: String,
+      ?hour_cycle: hour_cycle
     }
   end
 

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -86,6 +86,31 @@ RSpec.describe ICU4X::DateTimeFormat do
         expect { ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, time_zone: "Invalid/Timezone") }
           .to raise_error(ArgumentError, /invalid IANA timezone/)
       end
+
+      it "raises ArgumentError when hour_cycle is invalid" do
+        expect { ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h24) }
+          .to raise_error(ArgumentError, /hour_cycle must be :h11, :h12, :h23/)
+      end
+    end
+
+    context "with hour_cycle option" do
+      it "creates a DateTimeFormat instance with hour_cycle: :h12" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h12)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+      end
+
+      it "creates a DateTimeFormat instance with hour_cycle: :h23" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h23)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+      end
+
+      it "creates a DateTimeFormat instance with hour_cycle: :h11" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h11)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+      end
     end
 
     context "with valid time_zone" do
@@ -209,6 +234,52 @@ RSpec.describe ICU4X::DateTimeFormat do
       it "raises TypeError when argument does not respond to #to_time" do
         expect { formatter.format("2025-12-28") }
           .to raise_error(TypeError, /argument must be a Time object or respond to #to_time/)
+      end
+    end
+
+    context "with hour_cycle option" do
+      let(:locale) { ICU4X::Locale.parse("en-US") }
+      let(:midnight) { Time.utc(2025, 12, 28, 0, 30, 0) }
+      let(:noon) { Time.utc(2025, 12, 28, 12, 30, 0) }
+
+      it "formats midnight with h12 as 12:30 AM" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h12)
+
+        result = formatter.format(midnight)
+
+        expect(result).to eq("12:30:00\u202FAM")
+      end
+
+      it "formats midnight with h23 as 00:30" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h23)
+
+        result = formatter.format(midnight)
+
+        expect(result).to eq("00:30:00")
+      end
+
+      it "formats midnight with h11 as 0:30 AM" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h11)
+
+        result = formatter.format(midnight)
+
+        expect(result).to eq("0:30:00\u202FAM")
+      end
+
+      it "formats noon with h12 as 12:30 PM" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h12)
+
+        result = formatter.format(noon)
+
+        expect(result).to eq("12:30:00\u202FPM")
+      end
+
+      it "formats noon with h23 as 12:30" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h23)
+
+        result = formatter.format(noon)
+
+        expect(result).to eq("12:30:00")
       end
     end
 
@@ -388,6 +459,18 @@ RSpec.describe ICU4X::DateTimeFormat do
       formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, calendar: :japanese)
 
       expect(formatter.resolved_options).to include(calendar: :japanese)
+    end
+
+    it "returns hour_cycle when specified" do
+      formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h23)
+
+      expect(formatter.resolved_options).to include(hour_cycle: :h23)
+    end
+
+    it "does not return hour_cycle when not specified" do
+      formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short)
+
+      expect(formatter.resolved_options).not_to have_key(:hour_cycle)
     end
   end
 


### PR DESCRIPTION
## Summary

Add `hour_cycle` option to `DateTimeFormat` for controlling 12-hour vs 24-hour time display.

## Changes

- Add `hour_cycle` option with values `:h11`, `:h12`, `:h23`
- Include `hour_cycle` in `resolved_options` output
- Update RBS, YARD documentation, and markdown docs

Closes #112
