### PR TITLE
:memo: Document numbering system support via locale extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Document numbering system support via BCP 47 locale extensions (`-u-nu-xxx`) for `NumberFormat`, `DateTimeFormat`, and `RelativeTimeFormat` (#127)
 - `hour_cycle` option for `ICU4X::DateTimeFormat` to control 12/24-hour time display (#112)
 - `ICU4X::RelativeTimeFormat#format_to_parts` method for breaking down formatted output into typed parts (#117)
 - `ICU4X::ListFormat#format_to_parts` method for breaking down formatted output into typed parts (#116)

--- a/doc/datetime_format.md
+++ b/doc/datetime_format.md
@@ -209,6 +209,26 @@ dtf.resolved_options
 # }
 ```
 
+### Numbering System
+
+Specify a numbering system using BCP 47 locale extensions (`-u-nu-xxx`):
+
+```ruby
+# Han decimal numerals
+locale = ICU4X::Locale.parse("ja-JP-u-nu-hanidec")
+dtf = ICU4X::DateTimeFormat.new(locale, provider: provider, date_style: :long)
+dtf.format(Time.utc(2025, 12, 28))
+# => "二〇二五年一二月二八日"
+
+# Thai numerals
+locale = ICU4X::Locale.parse("th-TH-u-nu-thai")
+dtf = ICU4X::DateTimeFormat.new(locale, provider: provider, date_style: :short)
+dtf.format(Time.utc(2025, 12, 28))
+# => "๒๘/๑๒/๖๘"
+```
+
+See [NumberFormat - Numbering System](number_format.md#numbering-system) for available numbering systems.
+
 ---
 
 ## Timezone Management

--- a/doc/intl_compatibility.md
+++ b/doc/intl_compatibility.md
@@ -36,7 +36,16 @@ This document tracks which JavaScript Intl API options are supported in ICU4X Ru
 |--------|-------------|--------|
 | `day_period` | AM/PM display style | Possible |
 | Component options | Individual field control (year, month, day, etc.) | Experimental |
-| `numbering_system` | Numbering system selection | Possible |
+
+### Numbering System
+
+Numbering system is supported via BCP 47 locale extension (`-u-nu-xxx`):
+
+```ruby
+locale = ICU4X::Locale.parse("ja-JP-u-nu-hanidec")
+formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long)
+formatter.format(Time.utc(2025, 12, 28))  # => "二〇二五年一二月二八日"
+```
 
 ---
 
@@ -71,7 +80,16 @@ This document tracks which JavaScript Intl API options are supported in ICU4X Ru
 | `sign_display` | always/never/exceptZero | Planned |
 | `minimum_significant_digits` | Significant digits control | Possible |
 | `maximum_significant_digits` | Significant digits control | Possible |
-| `numbering_system` | Numbering system selection | Possible |
+
+### Numbering System
+
+Numbering system is supported via BCP 47 locale extension (`-u-nu-xxx`):
+
+```ruby
+locale = ICU4X::Locale.parse("ja-JP-u-nu-hanidec")
+formatter = ICU4X::NumberFormat.new(locale, provider:)
+formatter.format(1234)  # => "一,二三四"
+```
 
 ---
 
@@ -109,11 +127,15 @@ This document tracks which JavaScript Intl API options are supported in ICU4X Ru
 - `format(value, unit)` - Format a relative time value
 - `format_to_parts(value, unit)` - Get formatted parts array
 
-### Missing Options
+### Numbering System
 
-| Option | Intl Feature | Status |
-|--------|-------------|--------|
-| `numbering_system` | Numbering system selection | Possible |
+Numbering system is supported via BCP 47 locale extension (`-u-nu-xxx`):
+
+```ruby
+locale = ICU4X::Locale.parse("ja-u-nu-hanidec")
+rtf = ICU4X::RelativeTimeFormat.new(locale, provider:)
+rtf.format(-3, :day)  # => "三 日前"
+```
 
 ---
 
@@ -169,12 +191,11 @@ This document tracks which JavaScript Intl API options are supported in ICU4X Ru
 ### Medium Priority (Experimental Features)
 
 1. **DateTimeFormat component options** - Experimental but in demand
-2. **numbering_system** - Useful for multilingual support
 
 ### Low Priority (Waiting for ICU4X)
 
-3. **NumberFormat extensions** - Waiting for ICU4X #6804 (currency_display, unit, compact, etc.)
-4. **DisplayNames additional types** - Blocked (currency, calendar, date_time_field not in ICU4X displaynames module)
+2. **NumberFormat extensions** - Waiting for ICU4X #6804 (currency_display, unit, compact, etc.)
+3. **DisplayNames additional types** - Blocked (currency, calendar, date_time_field not in ICU4X displaynames module)
 
 ---
 

--- a/doc/number_format.md
+++ b/doc/number_format.md
@@ -185,6 +185,51 @@ nf.format(BigDecimal("12345678901234567890.123456789"))
 
 ---
 
+## Numbering System
+
+Specify a numbering system using BCP 47 locale extensions (`-u-nu-xxx`).
+
+### Available Numbering Systems
+
+| Code | Name | Example |
+|------|------|---------|
+| `latn` | Latin (default) | 0, 1, 2, 3 |
+| `arab` | Arabic-Indic | ٠, ١, ٢, ٣ |
+| `hanidec` | Han decimal | 〇, 一, 二, 三 |
+| `thai` | Thai | ๐, ๑, ๒, ๓ |
+| `deva` | Devanagari | ०, १, २, ३ |
+| `jpan` | Japanese | Not supported |
+
+### Examples
+
+```ruby
+# Han decimal numerals (Chinese/Japanese)
+locale = ICU4X::Locale.parse("ja-JP-u-nu-hanidec")
+nf = ICU4X::NumberFormat.new(locale, provider: provider)
+nf.format(1234)
+# => "一,二三四"
+
+# Arabic-Indic numerals
+locale = ICU4X::Locale.parse("ar-EG-u-nu-arab")
+nf = ICU4X::NumberFormat.new(locale, provider: provider)
+nf.format(1234)
+# => "١٬٢٣٤"
+
+# Override default to Latin numerals
+locale = ICU4X::Locale.parse("ar-EG-u-nu-latn")
+nf = ICU4X::NumberFormat.new(locale, provider: provider)
+nf.format(1234)
+# => "1,234"
+
+# Thai numerals
+locale = ICU4X::Locale.parse("th-TH-u-nu-thai")
+nf = ICU4X::NumberFormat.new(locale, provider: provider)
+nf.format(1234)
+# => "๑,๒๓๔"
+```
+
+---
+
 ## Numeric Type Conversion
 
 ### Supported Ruby Types

--- a/doc/relative_time_format.md
+++ b/doc/relative_time_format.md
@@ -196,6 +196,28 @@ parts.map(&:value).join  # => "3 days ago"
 
 ---
 
+## Numbering System
+
+Specify a numbering system using BCP 47 locale extensions (`-u-nu-xxx`):
+
+```ruby
+# Han decimal numerals
+locale = ICU4X::Locale.parse("ja-u-nu-hanidec")
+rtf = ICU4X::RelativeTimeFormat.new(locale, provider: provider)
+rtf.format(-3, :day)
+# => "三 日前"
+
+# Arabic-Indic numerals
+locale = ICU4X::Locale.parse("ar-u-nu-arab")
+rtf = ICU4X::RelativeTimeFormat.new(locale, provider: provider)
+rtf.format(-3, :day)
+# => "قبل ٣ أيام"
+```
+
+See [NumberFormat - Numbering System](number_format.md#numbering-system) for available numbering systems.
+
+---
+
 ## Notes
 
 - Negative values represent past time ("X ago")

--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -446,6 +446,11 @@
 #     #   formatter = ICU4X::NumberFormat.new(locale, style: :percent)
 #     #   formatter.format(0.42)  #=> "42%"
 #     #
+#     # @example Han decimal numerals via locale extension
+#     #   locale = ICU4X::Locale.parse("ja-JP-u-nu-hanidec")
+#     #   formatter = ICU4X::NumberFormat.new(locale, provider: provider)
+#     #   formatter.format(1234)  #=> "一,二三四"
+#     #
 #     class NumberFormat
 #       # Creates a new NumberFormat instance.
 #       #
@@ -536,6 +541,11 @@
 #     #   formatter = ICU4X::DateTimeFormat.new(locale, date_style: :long, calendar: :japanese)
 #     #   formatter.format(Time.now)  #=> "令和8年1月1日"
 #     #
+#     # @example Han decimal numerals via locale extension
+#     #   locale = ICU4X::Locale.parse("ja-JP-u-nu-hanidec")
+#     #   formatter = ICU4X::DateTimeFormat.new(locale, provider: provider, date_style: :long)
+#     #   formatter.format(Time.utc(2025, 12, 28))  #=> "二〇二五年一二月二八日"
+#     #
 #     class DateTimeFormat
 #       # Creates a new DateTimeFormat instance.
 #       #
@@ -619,6 +629,11 @@
 #     #   formatter = ICU4X::RelativeTimeFormat.new(locale, numeric: :auto)
 #     #   formatter.format(-1, :day)   #=> "yesterday"
 #     #   formatter.format(0, :day)    #=> "today"
+#     #
+#     # @example Han decimal numerals via locale extension
+#     #   locale = ICU4X::Locale.parse("ja-u-nu-hanidec")
+#     #   formatter = ICU4X::RelativeTimeFormat.new(locale, provider: provider)
+#     #   formatter.format(-3, :day)  #=> "三 日前"
 #     #
 #     class RelativeTimeFormat
 #       # Creates a new RelativeTimeFormat instance.

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -325,6 +325,34 @@ RSpec.describe ICU4X::DateTimeFormat do
     end
   end
 
+  describe "#format with numbering system" do
+    context "with Han decimal numerals (hanidec)" do
+      let(:locale) { ICU4X::Locale.parse("ja-JP-u-nu-hanidec") }
+      let(:formatter) { ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long) }
+
+      it "formats date using Han decimal numerals" do
+        result = formatter.format(Time.utc(2025, 12, 28))
+
+        expect(result).to eq("二〇二五年一二月二八日")
+      end
+
+      it "includes numbering system in resolved_options locale" do
+        expect(formatter.resolved_options[:locale]).to eq("ja-JP-u-nu-hanidec")
+      end
+    end
+
+    context "with Thai numerals (thai)" do
+      let(:locale) { ICU4X::Locale.parse("th-TH-u-nu-thai") }
+      let(:formatter) { ICU4X::DateTimeFormat.new(locale, provider:, date_style: :short) }
+
+      it "formats date using Thai numerals" do
+        result = formatter.format(Time.utc(2025, 12, 28))
+
+        expect(result).to include("๒๘")
+      end
+    end
+  end
+
   describe "#format_to_parts" do
     context "with en-US locale and date_style" do
       let(:locale) { ICU4X::Locale.parse("en-US") }

--- a/spec/icu4x/number_format_spec.rb
+++ b/spec/icu4x/number_format_spec.rb
@@ -429,6 +429,50 @@ RSpec.describe ICU4X::NumberFormat do
     end
   end
 
+  describe "#format with numbering system" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    context "with Han decimal numerals (hanidec)" do
+      let(:locale) { ICU4X::Locale.parse("ja-JP-u-nu-hanidec") }
+      let(:formatter) { ICU4X::NumberFormat.new(locale, provider:) }
+
+      it "formats using Han decimal numerals" do
+        expect(formatter.format(1234)).to eq("一,二三四")
+      end
+
+      it "includes numbering system in resolved_options locale" do
+        expect(formatter.resolved_options[:locale]).to eq("ja-JP-u-nu-hanidec")
+      end
+    end
+
+    context "with Arabic-Indic numerals (arab)" do
+      let(:locale) { ICU4X::Locale.parse("ar-EG-u-nu-arab") }
+      let(:formatter) { ICU4X::NumberFormat.new(locale, provider:) }
+
+      it "formats using Arabic-Indic numerals" do
+        expect(formatter.format(1234)).to eq("١٬٢٣٤")
+      end
+    end
+
+    context "with Thai numerals (thai)" do
+      let(:locale) { ICU4X::Locale.parse("th-TH-u-nu-thai") }
+      let(:formatter) { ICU4X::NumberFormat.new(locale, provider:) }
+
+      it "formats using Thai numerals" do
+        expect(formatter.format(1234)).to eq("๑,๒๓๔")
+      end
+    end
+
+    context "with Latin numerals override (latn)" do
+      let(:locale) { ICU4X::Locale.parse("ar-EG-u-nu-latn") }
+      let(:formatter) { ICU4X::NumberFormat.new(locale, provider:) }
+
+      it "overrides default to use Latin numerals" do
+        expect(formatter.format(1234)).to eq("1,234")
+      end
+    end
+  end
+
   describe "#format_to_parts" do
     let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
     let(:locale) { ICU4X::Locale.parse("en-US") }

--- a/spec/icu4x/relative_time_format_spec.rb
+++ b/spec/icu4x/relative_time_format_spec.rb
@@ -275,6 +275,36 @@ RSpec.describe ICU4X::RelativeTimeFormat do
     end
   end
 
+  describe "#format with numbering system" do
+    let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
+
+    context "with Han decimal numerals (hanidec)" do
+      let(:locale) { ICU4X::Locale.parse("ja-u-nu-hanidec") }
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(locale, provider:) }
+
+      it "formats using Han decimal numerals" do
+        result = rtf.format(-3, :day)
+
+        expect(result).to eq("三 日前")
+      end
+
+      it "includes numbering system in resolved_options locale" do
+        expect(rtf.resolved_options[:locale]).to eq("ja-u-nu-hanidec")
+      end
+    end
+
+    context "with Arabic-Indic numerals (arab)" do
+      let(:locale) { ICU4X::Locale.parse("ar-u-nu-arab") }
+      let(:rtf) { ICU4X::RelativeTimeFormat.new(locale, provider:) }
+
+      it "formats using Arabic-Indic numerals" do
+        result = rtf.format(-3, :day)
+
+        expect(result).to include("٣")
+      end
+    end
+  end
+
   describe "#format_to_parts" do
     let(:provider) { ICU4X::DataProvider.from_blob(valid_blob_path) }
     let(:locale) { ICU4X::Locale.parse("en") }


### PR DESCRIPTION
## Summary

Document numbering system support via BCP 47 Unicode locale extensions (`-u-nu-xxx`).

## Changes

- Add specs for numbering system with NumberFormat, DateTimeFormat, and RelativeTimeFormat
- Add Numbering System sections to `doc/number_format.md`, `doc/datetime_format.md`, and `doc/relative_time_format.md`
- Update `doc/intl_compatibility.md` to reflect numbering system is supported via locale extension
- Add YARD documentation examples for numbering system usage

## Available Numbering Systems

| Code | Name | Example |
|------|------|---------|
| `latn` | Latin (default) | 0, 1, 2, 3 |
| `arab` | Arabic-Indic | ٠, ١, ٢, ٣ |
| `hanidec` | Han decimal | 〇, 一, 二, 三 |
| `thai` | Thai | ๐, ๑, ๒, ๓ |

## Usage Example

```ruby
locale = ICU4X::Locale.parse("ja-JP-u-nu-hanidec")
formatter = ICU4X::NumberFormat.new(locale, provider: provider)
formatter.format(1234)  # => "一,二三四"
```

Fixes #127
