### PR TITLE
:sparkles: Support default behavior when no options specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Default behavior for `ICU4X::DateTimeFormat` when no options specified, matching JavaScript Intl.DateTimeFormat (#130)
 - Component options for `ICU4X::DateTimeFormat` (`year`, `month`, `day`, `weekday`, `hour`, `minute`, `second`) as an alternative to style options (#129)
 - Document numbering system support via BCP 47 locale extensions (`-u-nu-xxx`) for `NumberFormat`, `DateTimeFormat`, and `RelativeTimeFormat` (#127)
 - `hour_cycle` option for `ICU4X::DateTimeFormat` to control 12/24-hour time display (#112)

--- a/doc/datetime_format.md
+++ b/doc/datetime_format.md
@@ -67,7 +67,20 @@ There are two ways to specify which date/time components to include:
 1. **Style options** (`date_style`, `time_style`) - Use predefined formatting patterns
 2. **Component options** (`year`, `month`, `day`, `weekday`, `hour`, `minute`, `second`) - Specify individual components
 
-At least one style option or component option must be specified. You can use `date_style` and `time_style` together, or combine multiple component options, but **style options and component options cannot be mixed** in the same formatter.
+You can use `date_style` and `time_style` together, or combine multiple component options, but **style options and component options cannot be mixed** in the same formatter.
+
+#### Default Behavior (No Options)
+
+When no options are specified, the formatter uses default component options equivalent to `year: :numeric, month: :numeric, day: :numeric`. This matches JavaScript's `Intl.DateTimeFormat` default behavior.
+
+```ruby
+dtf = ICU4X::DateTimeFormat.new(locale)
+dtf.format(Time.utc(2025, 2, 1))
+# => "2/1/25" (en-US)
+# => "2025/02/01" (ja-JP)
+```
+
+**Note:** The output format may differ slightly from JavaScript Intl due to ICU4X/CLDR pattern differences. See [Limitation: Default format differs from Intl](#limitation-default-format-differs-from-intl) for details.
 
 #### date_style / time_style
 
@@ -417,3 +430,16 @@ If you need abbreviated month names in English-like locales, consider:
 1. Using `date_style: :medium` instead of component options
 2. Post-processing the output if abbreviation is critical
 
+### Limitation: Default format differs from Intl
+
+When no options are specified, the default format may differ from JavaScript's `Intl.DateTimeFormat`:
+
+| Locale | ICU4X Ruby (default) | JavaScript Intl (default) |
+|--------|---------------------|---------------------------|
+| en-US | "2/1/25" | "2/1/2025" |
+| ja-JP | "2025/02/01" | "2025/2/1" |
+| de-DE | "01.02.25" | "1.2.2025" |
+
+This difference occurs because ICU4X uses CLDR's "short" date pattern for numeric-only formats, which typically includes 2-digit years and zero-padding in some locales. JavaScript Intl uses a different pattern that produces 4-digit years without padding.
+
+This appears to be a difference in how ICU4X and Intl interpret default formatting, and may not be addressable at the gem level.

--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -329,13 +329,20 @@ impl DateTimeFormat {
             ));
         }
 
-        // At least one of date_style, time_style, or component options must be specified
-        if !has_style_options && !has_component_options {
-            return Err(Error::new(
-                ruby.exception_arg_error(),
-                "at least one of date_style, time_style, or component options (year, month, day, etc.) must be specified",
-            ));
-        }
+        // Apply default component options if no options specified
+        // Default: year: :numeric, month: :numeric, day: :numeric
+        // This matches JavaScript Intl.DateTimeFormat default behavior
+        let component_options = if !has_style_options && !has_component_options {
+            ComponentOptions {
+                year: Some(YearStyle::Numeric),
+                month: Some(MonthStyle::Numeric),
+                day: Some(DayStyle::Numeric),
+                ..Default::default()
+            }
+        } else {
+            component_options
+        };
+        let has_component_options = !component_options.is_empty();
 
         // Extract time_zone option and parse it
         let time_zone: Option<String> =

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -62,11 +62,6 @@ RSpec.describe ICU4X::DateTimeFormat do
           .to raise_error(TypeError, /provider must be a DataProvider/)
       end
 
-      it "raises ArgumentError when neither style nor component options are specified" do
-        expect { ICU4X::DateTimeFormat.new(locale, provider:) }
-          .to raise_error(ArgumentError, /at least one of date_style, time_style, or component options/)
-      end
-
       it "raises ArgumentError when style and component options are used together" do
         expect { ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, year: :numeric) }
           .to raise_error(ArgumentError, %r{cannot use date_style/time_style together with component options})
@@ -228,6 +223,38 @@ RSpec.describe ICU4X::DateTimeFormat do
         formatter = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :long)
 
         expect(formatter).to be_a(ICU4X::DateTimeFormat)
+      end
+    end
+
+    context "with no options (default behavior)" do
+      it "creates with default component options" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+      end
+
+      it "uses year, month, day as default components" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:)
+
+        options = formatter.resolved_options
+        expect(options).to include(year: :numeric, month: :numeric, day: :numeric)
+      end
+
+      it "does not include time components by default" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:)
+
+        options = formatter.resolved_options
+        expect(options).not_to have_key(:hour)
+        expect(options).not_to have_key(:minute)
+        expect(options).not_to have_key(:second)
+      end
+
+      it "does not include style options when using defaults" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:)
+
+        options = formatter.resolved_options
+        expect(options).not_to have_key(:date_style)
+        expect(options).not_to have_key(:time_style)
       end
     end
   end
@@ -562,6 +589,40 @@ RSpec.describe ICU4X::DateTimeFormat do
 
         # month: :long triggers Long length
         expect(result).to include("12")
+      end
+    end
+
+    context "with default behavior (no options)" do
+      let(:time) { Time.utc(2025, 2, 1) }
+
+      it "formats with en-US locale" do
+        locale = ICU4X::Locale.parse("en-US")
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:)
+
+        result = formatter.format(time)
+
+        # Default uses year: :numeric, month: :numeric, day: :numeric with Short length
+        expect(result).to eq("2/1/25")
+      end
+
+      it "formats with ja-JP locale" do
+        locale = ICU4X::Locale.parse("ja-JP")
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:)
+
+        result = formatter.format(time)
+
+        # Default uses year: :numeric, month: :numeric, day: :numeric with Short length
+        expect(result).to eq("2025/02/01")
+      end
+
+      it "formats with de-DE locale" do
+        locale = ICU4X::Locale.parse("de-DE")
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:)
+
+        result = formatter.format(time)
+
+        # Default uses year: :numeric, month: :numeric, day: :numeric with Short length
+        expect(result).to eq("01.02.25")
       end
     end
   end


### PR DESCRIPTION
## Summary

Allow `DateTimeFormat` to be created without specifying `date_style` or `time_style`, matching JavaScript's `Intl.DateTimeFormat` default behavior.

## Changes

- When no options are specified, use default component options (`year: :numeric, month: :numeric, day: :numeric`)
- Remove validation error for no options specified
- Add tests for default behavior
- Document the default behavior and its limitation compared to JavaScript Intl

## Usage

```ruby
# Default behavior (no options)
dtf = ICU4X::DateTimeFormat.new(locale)
dtf.format(Time.utc(2025, 2, 1))
# => "2/1/25" (en-US)
# => "2025/02/01" (ja-JP)

# resolved_options shows the default components
dtf.resolved_options
# => { locale: "en-US", calendar: :gregory, year: :numeric, month: :numeric, day: :numeric }
```

## Known Limitation

The output format differs slightly from JavaScript Intl due to ICU4X/CLDR pattern differences:

| Locale | ICU4X Ruby | JavaScript Intl |
|--------|-----------|-----------------|
| en-US | "2/1/25" | "2/1/2025" |
| ja-JP | "2025/02/01" | "2025/2/1" |

This is documented in the datetime_format.md.

Closes #130