### PR TITLE
:sparkles: Add hour12 option to DateTimeFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `hour12` option for `ICU4X::DateTimeFormat` as a simpler alternative to `hour_cycle` (#132)
 - Default behavior for `ICU4X::DateTimeFormat` when no options specified, matching JavaScript Intl.DateTimeFormat (#130)
 - Component options for `ICU4X::DateTimeFormat` (`year`, `month`, `day`, `weekday`, `hour`, `minute`, `second`) as an alternative to style options (#129)
 - Document numbering system support via BCP 47 locale extensions (`-u-nu-xxx`) for `NumberFormat`, `DateTimeFormat`, and `RelativeTimeFormat` (#127)

--- a/doc/datetime_format.md
+++ b/doc/datetime_format.md
@@ -37,11 +37,12 @@ module ICU4X
     # @param time_zone [String, nil] IANA timezone name (e.g., "Asia/Tokyo")
     # @param calendar [Symbol] :gregory, :japanese, :buddhist, :chinese, :hebrew, :islamic, :persian, :indian, :ethiopian, :coptic, :roc, :dangi
     # @param hour_cycle [Symbol, nil] :h11 (0-11), :h12 (1-12), :h23 (0-23)
+    # @param hour12 [Boolean, nil] true for 12-hour format, false for 24-hour format
     # @raise [Error] If options are invalid
     def initialize(locale, provider: nil, date_style: nil, time_style: nil,
                    year: nil, month: nil, day: nil, weekday: nil,
                    hour: nil, minute: nil, second: nil,
-                   time_zone: nil, calendar: nil, hour_cycle: nil) = ...
+                   time_zone: nil, calendar: nil, hour_cycle: nil, hour12: nil) = ...
 
     # Format a time
     # @param time [Time, #to_time] Time to format (or any object responding to #to_time)
@@ -149,6 +150,27 @@ dtf = ICU4X::DateTimeFormat.new(
   hour_cycle: :h23
 )
 dtf.format(Time.utc(2025, 1, 1, 0, 30))  # => "00:30:00"
+```
+
+#### hour12
+
+A simpler alternative to `hour_cycle` for toggling between 12-hour and 24-hour formats.
+
+| Value | Description | Equivalent |
+|-------|-------------|------------|
+| `true` | 12-hour format | `hour_cycle: :h12` |
+| `false` | 24-hour format | `hour_cycle: :h23` |
+
+If both `hour12` and `hour_cycle` are specified, `hour_cycle` takes precedence.
+
+```ruby
+# 12-hour format
+dtf = ICU4X::DateTimeFormat.new(locale, time_style: :short, hour12: true)
+dtf.format(Time.utc(2025, 1, 1, 14, 30))  # => "2:30:00 PM"
+
+# 24-hour format
+dtf = ICU4X::DateTimeFormat.new(locale, time_style: :short, hour12: false)
+dtf.format(Time.utc(2025, 1, 1, 14, 30))  # => "14:30:00"
 ```
 
 #### Component Options

--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -379,6 +379,16 @@ impl DateTimeFormat {
         let hour_cycle =
             helpers::extract_symbol(ruby, &kwargs, "hour_cycle", HourCycle::from_ruby_symbol)?;
 
+        // Extract hour12 option and convert to hour_cycle if hour_cycle is not specified
+        // hour12: true → :h12, hour12: false → :h23
+        let hour12: Option<bool> = kwargs.lookup::<_, Option<bool>>(ruby.to_symbol("hour12"))?;
+        let hour_cycle = match (hour_cycle, hour12) {
+            (Some(hc), _) => Some(hc), // hour_cycle takes precedence
+            (None, Some(true)) => Some(HourCycle::H12),
+            (None, Some(false)) => Some(HourCycle::H23),
+            (None, None) => None,
+        };
+
         // Get the error exception class
         let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 

--- a/lib/icu4x/yard_docs.rb
+++ b/lib/icu4x/yard_docs.rb
@@ -572,9 +572,9 @@
 #       # @param time_zone [String, nil] IANA time zone identifier (e.g., "America/New_York")
 #       # @param calendar [Symbol] calendar system to use
 #       # @param hour_cycle [Symbol, nil] hour cycle: `:h11` (0-11), `:h12` (1-12), or `:h23` (0-23)
+#       # @param hour12 [Boolean, nil] `true` for 12-hour format, `false` for 24-hour format
 #       # @return [DateTimeFormat] a new instance
 #       # @raise [ArgumentError] if both style and component options are specified
-#       # @raise [ArgumentError] if neither style nor component options are specified
 #       # @raise [DataError] if data for the locale is unavailable
 #       #
 #       # @example With style options
@@ -583,14 +583,18 @@
 #       # @example With component options
 #       #   formatter = ICU4X::DateTimeFormat.new(locale, year: :numeric, month: :long, day: :numeric)
 #       #
-#       # @example With 24-hour format
+#       # @example With 24-hour format using hour_cycle
 #       #   formatter = ICU4X::DateTimeFormat.new(locale, time_style: :short, hour_cycle: :h23)
 #       #   formatter.format(Time.utc(2025, 1, 1, 0, 30))  #=> "00:30:00"
+#       #
+#       # @example With 12-hour format using hour12
+#       #   formatter = ICU4X::DateTimeFormat.new(locale, time_style: :short, hour12: true)
+#       #   formatter.format(Time.utc(2025, 1, 1, 14, 30))  #=> "2:30:00 PM"
 #       #
 #       def initialize(locale, provider: nil, date_style: nil, time_style: nil,
 #                      year: nil, month: nil, day: nil, weekday: nil,
 #                      hour: nil, minute: nil, second: nil,
-#                      time_zone: nil, calendar: :gregory, hour_cycle: nil); end
+#                      time_zone: nil, calendar: :gregory, hour_cycle: nil, hour12: nil); end
 #
 #       # Formats a time value according to the configured options.
 #       #

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -120,7 +120,8 @@ module ICU4X
       ?second: second_style,
       ?time_zone: String,
       ?calendar: datetime_calendar,
-      ?hour_cycle: hour_cycle
+      ?hour_cycle: hour_cycle,
+      ?hour12: bool
     ) -> DateTimeFormat
 
     def format: (Time time) -> String

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -148,6 +148,20 @@ RSpec.describe ICU4X::DateTimeFormat do
       end
     end
 
+    context "with hour12 option" do
+      it "creates a DateTimeFormat instance with hour12: true" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour12: true)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+      end
+
+      it "creates a DateTimeFormat instance with hour12: false" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour12: false)
+
+        expect(formatter).to be_a(ICU4X::DateTimeFormat)
+      end
+    end
+
     context "with valid time_zone" do
       it "creates a DateTimeFormat instance with Asia/Tokyo" do
         formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, time_zone: "Asia/Tokyo")
@@ -411,6 +425,36 @@ RSpec.describe ICU4X::DateTimeFormat do
         result = formatter.format(noon)
 
         expect(result).to eq("12:30:00")
+      end
+    end
+
+    context "with hour12 option" do
+      let(:locale) { ICU4X::Locale.parse("en-US") }
+      let(:afternoon) { Time.utc(2025, 12, 28, 14, 30, 0) }
+
+      it "formats with hour12: true as 12-hour format" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour12: true)
+
+        result = formatter.format(afternoon)
+
+        expect(result).to eq("2:30:00\u202FPM")
+      end
+
+      it "formats with hour12: false as 24-hour format" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour12: false)
+
+        result = formatter.format(afternoon)
+
+        expect(result).to eq("14:30:00")
+      end
+
+      it "hour_cycle takes precedence over hour12" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour_cycle: :h23, hour12: true)
+
+        result = formatter.format(afternoon)
+
+        # hour_cycle: :h23 should override hour12: true
+        expect(result).to eq("14:30:00")
       end
     end
 


### PR DESCRIPTION
## Summary

Add `hour12` option to `DateTimeFormat` as a simpler alternative to `hour_cycle`, matching JavaScript's `Intl.DateTimeFormat` API.

## Changes

- Add `hour12` option extraction in Rust
- Convert `hour12` to `hour_cycle` internally (true→:h12, false→:h23)
- `hour_cycle` takes precedence when both are specified
- Add tests for `hour12` option
- Update documentation (doc/datetime_format.md, YARD docs, RBS)

## Usage

```ruby
# 12-hour format
formatter = ICU4X::DateTimeFormat.new(locale, time_style: :short, hour12: true)
formatter.format(Time.utc(2025, 1, 1, 14, 30))  # => "2:30:00 PM"

# 24-hour format
formatter = ICU4X::DateTimeFormat.new(locale, time_style: :short, hour12: false)
formatter.format(Time.utc(2025, 1, 1, 14, 30))  # => "14:30:00"

# hour_cycle takes precedence
formatter = ICU4X::DateTimeFormat.new(locale, time_style: :short, hour_cycle: :h23, hour12: true)
formatter.format(Time.utc(2025, 1, 1, 14, 30))  # => "14:30:00"
```

Closes #132