### PR TITLE
:sparkles: Add Locale.from_env to create locale from environment variables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,11 @@ inherit_from: .rubocop_todo.yml
 
 # Project-specific settings
 
+# ENV[] returning nil is intentional for locale environment variable lookup
+Style/FetchEnvVar:
+  Exclude:
+    - lib/icu4x.rb
+
 # Native extension classes appear static from Ruby side but have methods defined in Rust
 Style/StaticClass:
   Exclude:

--- a/sig/icu4x.rbs
+++ b/sig/icu4x.rbs
@@ -35,7 +35,10 @@ module ICU4X
     def self.available_markers: () -> Array[String]
   end
 
+  type locale_category = :collate | :ctype | :messages | :monetary | :numeric | :time
+
   class Locale
+    def self.from_env: (?category: locale_category) -> Locale
     def self.parse_bcp47: (String locale_str) -> Locale
     alias self.parse self.parse_bcp47
     def self.parse_posix: (String posix_str) -> Locale


### PR DESCRIPTION
## Summary
Add `Locale.from_env` class method that creates a locale instance from environment variables, checking `LC_ALL`, `LC_{category}`, and `LANG` in order.

## Changes
- Add `Locale.from_env(category: :messages)` class method in Ruby
- Validate category against POSIX-defined set, raising `ArgumentError` for unknown categories
- Exclude `Style/FetchEnvVar` for `lib/icu4x.rb` in RuboCop config
- Add RBS type definition for `locale_category` and `from_env`

## Usage
```ruby
locale = ICU4X::Locale.from_env
locale = ICU4X::Locale.from_env(category: :collate)
```

Closes #136
