### PR TITLE
:bug: Remove deprecated AnyCalendarKind::JapaneseExtended

### DIFF
--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -218,7 +218,7 @@ impl Calendar {
             | AnyCalendarKind::HijriTabularTypeIIThursday
             | AnyCalendarKind::HijriUmmAlQura => Calendar::Islamic,
             AnyCalendarKind::Iso => Calendar::Gregory,
-            AnyCalendarKind::Japanese | AnyCalendarKind::JapaneseExtended => Calendar::Japanese,
+            AnyCalendarKind::Japanese => Calendar::Japanese,
             AnyCalendarKind::Persian => Calendar::Persian,
             AnyCalendarKind::Roc => Calendar::Roc,
             _ => Calendar::Gregory,


### PR DESCRIPTION
## Summary

Remove deprecated `AnyCalendarKind::JapaneseExtended` variant, which was deprecated in ICU4X 2.2 in favor of `AnyCalendarKind::Japanese`.

## Changes

- Replace `AnyCalendarKind::JapaneseExtended` with `AnyCalendarKind::Japanese` in the calendar kind match arm
- Both variants mapped to the same `Calendar::Japanese` value, so there is no behavioral change

Closes #141
