### PR TITLE
:bug: Fix hour12: option to use Clock12/Clock24 instead of H12/H23

### DIFF
--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -264,6 +264,7 @@ pub struct DateTimeFormat {
     jiff_timezone: Option<TimeZone>,
     calendar: Calendar,
     hour_cycle: Option<HourCycle>,
+    hour12: Option<bool>,
     component_options: Option<ComponentOptions>,
 }
 
@@ -379,15 +380,7 @@ impl DateTimeFormat {
         let hour_cycle =
             helpers::extract_symbol(ruby, &kwargs, "hour_cycle", HourCycle::from_ruby_symbol)?;
 
-        // Extract hour12 option and convert to hour_cycle if hour_cycle is not specified
-        // hour12: true → :h12, hour12: false → :h23
         let hour12: Option<bool> = kwargs.lookup::<_, Option<bool>>(ruby.to_symbol("hour12"))?;
-        let hour_cycle = match (hour_cycle, hour12) {
-            (Some(hc), _) => Some(hc), // hour_cycle takes precedence
-            (None, Some(true)) => Some(HourCycle::H12),
-            (None, Some(false)) => Some(HourCycle::H23),
-            (None, None) => None,
-        };
 
         // Get the error exception class
         let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
@@ -414,6 +407,8 @@ impl DateTimeFormat {
         }
         if let Some(hc) = hour_cycle {
             prefs.hour_cycle = Some(hc.to_icu_hour_cycle());
+        } else if let Some(h12) = hour12 {
+            prefs.hour_cycle = Some(if h12 { IcuHourCycle::Clock12 } else { IcuHourCycle::Clock24 });
         }
 
         let formatter =
@@ -437,6 +432,7 @@ impl DateTimeFormat {
             jiff_timezone,
             calendar: resolved_calendar,
             hour_cycle,
+            hour12,
             component_options: if has_component_options {
                 Some(component_options)
             } else {
@@ -721,7 +717,7 @@ impl DateTimeFormat {
     /// Get the resolved options
     ///
     /// # Returns
-    /// A hash with :locale, :calendar, :date_style, :time_style, and optionally :time_zone, :hour_cycle
+    /// A hash with :locale, :calendar, :date_style, :time_style, and optionally :time_zone, :hour_cycle, :hour12
     fn resolved_options(&self) -> Result<RHash, Error> {
         let ruby = Ruby::get().expect("Ruby runtime should be available");
         let hash = ruby.hash_new();
@@ -755,6 +751,10 @@ impl DateTimeFormat {
                 ruby.to_symbol("hour_cycle"),
                 ruby.to_symbol(hc.to_symbol_name()),
             )?;
+        }
+
+        if let Some(h12) = self.hour12 {
+            hash.aset(ruby.to_symbol("hour12"), h12)?;
         }
 
         // Add component options if they were used

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -847,6 +847,26 @@ RSpec.describe ICU4X::DateTimeFormat do
       expect(formatter.resolved_options).not_to have_key(:hour_cycle)
     end
 
+    it "returns hour12 when specified as true" do
+      formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour12: true)
+
+      expect(formatter.resolved_options).to include(hour12: true)
+      expect(formatter.resolved_options).not_to have_key(:hour_cycle)
+    end
+
+    it "returns hour12 when specified as false" do
+      formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short, hour12: false)
+
+      expect(formatter.resolved_options).to include(hour12: false)
+      expect(formatter.resolved_options).not_to have_key(:hour_cycle)
+    end
+
+    it "does not return hour12 when not specified" do
+      formatter = ICU4X::DateTimeFormat.new(locale, provider:, time_style: :short)
+
+      expect(formatter.resolved_options).not_to have_key(:hour12)
+    end
+
     context "with component options" do
       it "returns year when specified" do
         formatter = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :numeric, day: :numeric)


### PR DESCRIPTION
## Summary

Fix `hour12: true/false` to use `Clock12`/`Clock24` instead of `H12`/`H23`, so the locale can choose the appropriate variant rather than fixing a specific hour cycle.

## Changes

- Map `hour12: true` to `HourCycle::Clock12` (was `H12`)
- Map `hour12: false` to `HourCycle::Clock24` (was `H23`)
- Store `hour12` separately from `hour_cycle` in the struct
- Reflect `hour12` independently in `resolved_options`

## Before

```ruby
# hour12: true fixed H12 (1–12), ignoring locale preference for H11
# hour12: false fixed H23 (0–23), ignoring locale preference for H24
```

## After

```ruby
# hour12: true uses Clock12 — locale decides H11 or H12
# hour12: false uses Clock24 — locale decides H23 or H24
```

Fixes #145
