### PR TITLE
:sparkles: Add locale variant APIs to ICU4X::Locale

### DIFF
--- a/ext/icu4x/src/locale.rs
+++ b/ext/icu4x/src/locale.rs
@@ -1,5 +1,6 @@
 use crate::helpers;
 use icu_locale::{Locale as IcuLocale, LocaleExpander, TransformResult};
+use icu_locale::subtags::Variant;
 use magnus::{Error, RHash, RModule, Ruby, function, method, prelude::*, typed_data::Obj};
 use std::cell::RefCell;
 
@@ -204,6 +205,57 @@ impl Locale {
             inner: RefCell::new(IcuLocale::from(new_id)),
         }
     }
+
+    /// Get the list of variants
+    fn variants(&self) -> Vec<String> {
+        self.inner
+            .borrow()
+            .id
+            .variants
+            .iter()
+            .map(|v| v.to_string())
+            .collect()
+    }
+
+    fn parse_variant(s: &str) -> Result<Variant, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime should be available");
+        s.parse::<Variant>().map_err(|e| {
+            Error::new(
+                helpers::get_exception_class(&ruby, "ICU4X::LocaleError"),
+                format!("Invalid variant: {e}"),
+            )
+        })
+    }
+
+    /// Add a variant in place; returns self if added, nil if already present
+    fn add_variant_bang(rb_self: Obj<Self>, variant_str: String) -> Result<Option<Obj<Self>>, Error> {
+        let variant = Self::parse_variant(&variant_str)?;
+        let added = rb_self.inner.borrow_mut().id.variants.push(variant);
+        Ok(if added { Some(rb_self) } else { None })
+    }
+
+    /// Return a new Locale with the variant added
+    fn add_variant(&self, variant_str: String) -> Result<Self, Error> {
+        let variant = Self::parse_variant(&variant_str)?;
+        let mut new_locale = self.inner.borrow().clone();
+        new_locale.id.variants.push(variant);
+        Ok(Self { inner: RefCell::new(new_locale) })
+    }
+
+    /// Remove a variant in place; returns self if removed, nil if not present
+    fn remove_variant_bang(rb_self: Obj<Self>, variant_str: String) -> Result<Option<Obj<Self>>, Error> {
+        let variant = Self::parse_variant(&variant_str)?;
+        let removed = rb_self.inner.borrow_mut().id.variants.remove(&variant);
+        Ok(if removed { Some(rb_self) } else { None })
+    }
+
+    /// Return a new Locale with the variant removed
+    fn remove_variant(&self, variant_str: String) -> Result<Self, Error> {
+        let variant = Self::parse_variant(&variant_str)?;
+        let mut new_locale = self.inner.borrow().clone();
+        new_locale.id.variants.remove(&variant);
+        Ok(Self { inner: RefCell::new(new_locale) })
+    }
 }
 
 pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
@@ -221,5 +273,10 @@ pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     class.define_method("maximize", method!(Locale::maximize, 0))?;
     class.define_method("minimize!", method!(Locale::minimize_bang, 0))?;
     class.define_method("minimize", method!(Locale::minimize, 0))?;
+    class.define_method("variants", method!(Locale::variants, 0))?;
+    class.define_method("add_variant!", method!(Locale::add_variant_bang, 1))?;
+    class.define_method("add_variant", method!(Locale::add_variant, 1))?;
+    class.define_method("remove_variant!", method!(Locale::remove_variant_bang, 1))?;
+    class.define_method("remove_variant", method!(Locale::remove_variant, 1))?;
     Ok(())
 }

--- a/spec/icu4x/locale_spec.rb
+++ b/spec/icu4x/locale_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe ICU4X::Locale do
     it "returns multiple variants in sorted order" do
       locale = ICU4X::Locale.parse("en-macos-posix")
 
-      expect(locale.variants).to eq(["macos", "posix"])
+      expect(locale.variants).to eq(%w[macos posix])
     end
   end
 

--- a/spec/icu4x/locale_spec.rb
+++ b/spec/icu4x/locale_spec.rb
@@ -389,4 +389,133 @@ RSpec.describe ICU4X::Locale do
       expect(result.to_s).to eq("en")
     end
   end
+
+  describe "#variants" do
+    it "returns empty array when no variants" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      expect(locale.variants).to eq([])
+    end
+
+    it "returns variants as strings" do
+      locale = ICU4X::Locale.parse("en-US-posix")
+
+      expect(locale.variants).to eq(["posix"])
+    end
+
+    it "returns multiple variants in sorted order" do
+      locale = ICU4X::Locale.parse("en-macos-posix")
+
+      expect(locale.variants).to eq(["macos", "posix"])
+    end
+  end
+
+  describe "#add_variant!" do
+    it "adds the variant in place and returns self" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      result = locale.add_variant!("posix")
+
+      expect(result).to be(locale)
+      expect(locale.to_s).to eq("en-US-posix")
+    end
+
+    it "returns nil when variant is already present" do
+      locale = ICU4X::Locale.parse("en-US-posix")
+
+      expect(locale.add_variant!("posix")).to be_nil
+      expect(locale.to_s).to eq("en-US-posix")
+    end
+
+    it "maintains sorted order" do
+      locale = ICU4X::Locale.parse("en-posix")
+      locale.add_variant!("macos")
+
+      expect(locale.to_s).to eq("en-macos-posix")
+    end
+
+    it "raises LocaleError for invalid variant" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      expect { locale.add_variant!("!!!") }.to raise_error(ICU4X::LocaleError, /Invalid variant/)
+    end
+  end
+
+  describe "#add_variant" do
+    it "returns a new locale with the variant added" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      result = locale.add_variant("posix")
+
+      expect(result).not_to be(locale)
+      expect(result.to_s).to eq("en-US-posix")
+      expect(locale.to_s).to eq("en-US")
+    end
+
+    it "returns a new locale even when variant is already present" do
+      locale = ICU4X::Locale.parse("en-US-posix")
+
+      result = locale.add_variant("posix")
+
+      expect(result).not_to be(locale)
+      expect(result.to_s).to eq("en-US-posix")
+    end
+
+    it "raises LocaleError for invalid variant" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      expect { locale.add_variant("!!!") }.to raise_error(ICU4X::LocaleError, /Invalid variant/)
+    end
+  end
+
+  describe "#remove_variant!" do
+    it "removes the variant in place and returns self" do
+      locale = ICU4X::Locale.parse("en-US-posix")
+
+      result = locale.remove_variant!("posix")
+
+      expect(result).to be(locale)
+      expect(locale.to_s).to eq("en-US")
+    end
+
+    it "returns nil when variant is not present" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      expect(locale.remove_variant!("posix")).to be_nil
+      expect(locale.to_s).to eq("en-US")
+    end
+
+    it "raises LocaleError for invalid variant" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      expect { locale.remove_variant!("!!!") }.to raise_error(ICU4X::LocaleError, /Invalid variant/)
+    end
+  end
+
+  describe "#remove_variant" do
+    it "returns a new locale with the variant removed" do
+      locale = ICU4X::Locale.parse("en-US-posix")
+
+      result = locale.remove_variant("posix")
+
+      expect(result).not_to be(locale)
+      expect(result.to_s).to eq("en-US")
+      expect(locale.to_s).to eq("en-US-posix")
+    end
+
+    it "returns a new locale even when variant is not present" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      result = locale.remove_variant("posix")
+
+      expect(result).not_to be(locale)
+      expect(result.to_s).to eq("en-US")
+    end
+
+    it "raises LocaleError for invalid variant" do
+      locale = ICU4X::Locale.parse("en-US")
+
+      expect { locale.remove_variant("!!!") }.to raise_error(ICU4X::LocaleError, /Invalid variant/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Add variant read and mutation APIs to `ICU4X::Locale`, leveraging `Variants::push()` and `Variants::remove()` introduced in ICU4X 2.2.

## Changes

- Add `variants` — returns the list of variants as `Array<String>`
- Add `add_variant!` / `add_variant` — add a variant (in-place and non-destructive)
- Add `remove_variant!` / `remove_variant` — remove a variant (in-place and non-destructive)

## Notes

- Bang variants return `self` if modified, `nil` if unchanged — consistent with `maximize!` / `minimize!`
- ICU4X maintains variants in sorted, deduplicated order internally
- Invalid variant strings raise `ICU4X::LocaleError`

Fixes #143
