### PR TITLE
:bug: Require bigdecimal explicitly as a runtime dependency

### DIFF
--- a/ext/icu4x/src/number_format.rs
+++ b/ext/icu4x/src/number_format.rs
@@ -399,11 +399,7 @@ impl NumberFormat {
 
     /// Check if value is a BigDecimal
     fn is_big_decimal(ruby: &Ruby, value: Value) -> bool {
-        // Try to get BigDecimal class; if bigdecimal is not loaded, return false
-        if let Ok(bigdecimal_class) = ruby.eval::<Value>("defined?(BigDecimal) && BigDecimal") {
-            if bigdecimal_class.is_nil() {
-                return false;
-            }
+        if let Ok(bigdecimal_class) = ruby.eval::<Value>("BigDecimal") {
             if let Ok(class) = magnus::RClass::try_convert(bigdecimal_class) {
                 return value.is_kind_of(class);
             }

--- a/icu4x.gemspec
+++ b/icu4x.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/icu4x/extconf.rb"]
 
+  spec.add_dependency "bigdecimal", "~> 4.0"
   spec.add_dependency "dry-configurable", "~> 1.3"
   spec.add_dependency "rb_sys", "~> 0.9", ">= 0.9.124"
 end

--- a/lib/icu4x.rb
+++ b/lib/icu4x.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bigdecimal"
 require "dry-configurable"
 require "pathname"
 

--- a/spec/icu4x/number_format_spec.rb
+++ b/spec/icu4x/number_format_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bigdecimal"
 require "pathname"
 
 RSpec.describe ICU4X::NumberFormat do


### PR DESCRIPTION
## Summary

`NumberFormat#format` accepts `BigDecimal` as a documented input type, but `bigdecimal` was never declared as a dependency. Since Ruby 3.4 removed it from default gems, CI started failing. The `defined?(BigDecimal)` guard also made behavior load-order dependent.

## Changes

- Add `bigdecimal (~> 4.0)` as a runtime dependency in the gemspec
- Require `bigdecimal` in `lib/icu4x.rb` to guarantee availability
- Remove the `defined?(BigDecimal)` guard in `is_big_decimal`
- Remove redundant `require "bigdecimal"` from the spec

Fixes #149
