### PR TITLE
:sparkles: Add era: option to DateTimeFormat

### DIFF
--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -8,7 +8,7 @@ use icu::datetime::fieldsets::enums::{
     TimeFieldSet,
 };
 use icu::datetime::fieldsets::{self};
-use icu::datetime::options::Length;
+use icu::datetime::options::{Length, YearStyle as IcuYearStyle};
 use icu::datetime::input::DateTime;
 use icu::datetime::parts as dt_parts;
 use icu::datetime::{DateTimeFormatter, DateTimeFormatterPreferences};
@@ -63,6 +63,26 @@ impl HourCycle {
 enum YearStyle {
     Numeric,
     TwoDigit,
+}
+
+/// Era display option
+#[derive(Clone, Copy, PartialEq, Eq, RubySymbol)]
+enum EraStyle {
+    Auto,
+    Full,
+    WithEra,
+    Never,
+}
+
+impl EraStyle {
+    fn to_icu_year_style(self) -> IcuYearStyle {
+        match self {
+            EraStyle::Auto => IcuYearStyle::Auto,
+            EraStyle::Full => IcuYearStyle::Full,
+            EraStyle::WithEra => IcuYearStyle::WithEra,
+            EraStyle::Never => IcuYearStyle::NoEra,
+        }
+    }
 }
 
 /// Month component option
@@ -265,6 +285,7 @@ pub struct DateTimeFormat {
     calendar: Calendar,
     hour_cycle: Option<HourCycle>,
     hour12: Option<bool>,
+    era: Option<EraStyle>,
     component_options: Option<ComponentOptions>,
 }
 
@@ -382,6 +403,10 @@ impl DateTimeFormat {
 
         let hour12: Option<bool> = kwargs.lookup::<_, Option<bool>>(ruby.to_symbol("hour12"))?;
 
+        // Extract era option
+        let era =
+            helpers::extract_symbol(ruby, &kwargs, "era", EraStyle::from_ruby_symbol)?;
+
         // Get the error exception class
         let error_class = helpers::get_exception_class(ruby, "ICU4X::Error");
 
@@ -395,9 +420,9 @@ impl DateTimeFormat {
 
         // Create field set based on options
         let field_set = if has_component_options {
-            Self::create_field_set_from_components(ruby, &component_options)?
+            Self::create_field_set_from_components(ruby, &component_options, era)?
         } else {
-            Self::create_field_set_from_style(date_style, time_style)
+            Self::create_field_set_from_style(date_style, time_style, era)
         };
 
         // Create formatter with calendar and hour_cycle preferences
@@ -433,6 +458,7 @@ impl DateTimeFormat {
             calendar: resolved_calendar,
             hour_cycle,
             hour12,
+            era,
             component_options: if has_component_options {
                 Some(component_options)
             } else {
@@ -473,6 +499,7 @@ impl DateTimeFormat {
     fn create_field_set_from_components(
         ruby: &Ruby,
         opts: &ComponentOptions,
+        era: Option<EraStyle>,
     ) -> Result<CompositeDateTimeFieldSet, Error> {
         let has_date = opts.has_date_components();
         let has_time = opts.has_time_components();
@@ -481,9 +508,9 @@ impl DateTimeFormat {
         match (has_date, has_time) {
             (true, true) => {
                 // Date and time components
-                Ok(CompositeDateTimeFieldSet::DateTime(
-                    DateAndTimeFieldSet::YMDT(fieldsets::YMDT::for_length(length)),
-                ))
+                let fs = fieldsets::YMDT::for_length(length);
+                let fs = if let Some(s) = era { fs.with_year_style(s.to_icu_year_style()) } else { fs };
+                Ok(CompositeDateTimeFieldSet::DateTime(DateAndTimeFieldSet::YMDT(fs)))
             }
             (true, false) => {
                 // Date only - choose field set based on which components are specified
@@ -494,13 +521,17 @@ impl DateTimeFormat {
 
                 match (has_year, has_month, has_day, has_weekday) {
                     // Year + Month + Day + Weekday
-                    (true, true, true, true) => Ok(CompositeDateTimeFieldSet::Date(
-                        DateFieldSet::YMDE(fieldsets::YMDE::for_length(length)),
-                    )),
+                    (true, true, true, true) => {
+                        let fs = fieldsets::YMDE::for_length(length);
+                        let fs = if let Some(s) = era { fs.with_year_style(s.to_icu_year_style()) } else { fs };
+                        Ok(CompositeDateTimeFieldSet::Date(DateFieldSet::YMDE(fs)))
+                    }
                     // Year + Month + Day
-                    (true, true, true, false) => Ok(CompositeDateTimeFieldSet::Date(
-                        DateFieldSet::YMD(fieldsets::YMD::for_length(length)),
-                    )),
+                    (true, true, true, false) => {
+                        let fs = fieldsets::YMD::for_length(length);
+                        let fs = if let Some(s) = era { fs.with_year_style(s.to_icu_year_style()) } else { fs };
+                        Ok(CompositeDateTimeFieldSet::Date(DateFieldSet::YMD(fs)))
+                    }
                     // Month + Day + Weekday
                     (false, true, true, true) => Ok(CompositeDateTimeFieldSet::Date(
                         DateFieldSet::MDE(fieldsets::MDE::for_length(length)),
@@ -510,9 +541,11 @@ impl DateTimeFormat {
                         DateFieldSet::MD(fieldsets::MD::for_length(length)),
                     )),
                     // Year + Month (calendar period)
-                    (true, true, false, _) => Ok(CompositeDateTimeFieldSet::CalendarPeriod(
-                        CalendarPeriodFieldSet::YM(fieldsets::YM::for_length(length)),
-                    )),
+                    (true, true, false, _) => {
+                        let fs = fieldsets::YM::for_length(length);
+                        let fs = if let Some(s) = era { fs.with_year_style(s.to_icu_year_style()) } else { fs };
+                        Ok(CompositeDateTimeFieldSet::CalendarPeriod(CalendarPeriodFieldSet::YM(fs)))
+                    }
                     // Month only (calendar period)
                     (false, true, false, _) => Ok(CompositeDateTimeFieldSet::CalendarPeriod(
                         CalendarPeriodFieldSet::M(fieldsets::M::for_length(length)),
@@ -530,13 +563,17 @@ impl DateTimeFormat {
                         DateFieldSet::E(fieldsets::E::for_length(length)),
                     )),
                     // Year only (calendar period)
-                    (true, false, false, _) => Ok(CompositeDateTimeFieldSet::CalendarPeriod(
-                        CalendarPeriodFieldSet::Y(fieldsets::Y::for_length(length)),
-                    )),
+                    (true, false, false, _) => {
+                        let fs = fieldsets::Y::for_length(length);
+                        let fs = if let Some(s) = era { fs.with_year_style(s.to_icu_year_style()) } else { fs };
+                        Ok(CompositeDateTimeFieldSet::CalendarPeriod(CalendarPeriodFieldSet::Y(fs)))
+                    }
                     // Year + Day (not a standard combination, use YMD as fallback)
-                    (true, false, true, _) => Ok(CompositeDateTimeFieldSet::Date(
-                        DateFieldSet::YMD(fieldsets::YMD::for_length(length)),
-                    )),
+                    (true, false, true, _) => {
+                        let fs = fieldsets::YMD::for_length(length);
+                        let fs = if let Some(s) = era { fs.with_year_style(s.to_icu_year_style()) } else { fs };
+                        Ok(CompositeDateTimeFieldSet::Date(DateFieldSet::YMD(fs)))
+                    }
                     // Should not happen - we checked has_date_components
                     (false, false, false, false) => unreachable!(),
                 }
@@ -558,6 +595,7 @@ impl DateTimeFormat {
     fn create_field_set_from_style(
         date_style: Option<DateStyle>,
         time_style: Option<TimeStyle>,
+        era: Option<EraStyle>,
     ) -> CompositeDateTimeFieldSet {
         match (date_style, time_style) {
             (Some(ds), Some(ts)) => {
@@ -567,6 +605,7 @@ impl DateTimeFormat {
                     (DateStyle::Medium, _) => fieldsets::YMDT::medium(),
                     (DateStyle::Short, _) => fieldsets::YMDT::short(),
                 };
+                let ymdt = if let Some(s) = era { ymdt.with_year_style(s.to_icu_year_style()) } else { ymdt };
                 CompositeDateTimeFieldSet::DateTime(DateAndTimeFieldSet::YMDT(ymdt))
             }
             (Some(ds), None) => {
@@ -576,6 +615,7 @@ impl DateTimeFormat {
                     DateStyle::Medium => fieldsets::YMD::medium(),
                     DateStyle::Short => fieldsets::YMD::short(),
                 };
+                let ymd = if let Some(s) = era { ymd.with_year_style(s.to_icu_year_style()) } else { ymd };
                 CompositeDateTimeFieldSet::Date(DateFieldSet::YMD(ymd))
             }
             (None, Some(ts)) => {
@@ -755,6 +795,13 @@ impl DateTimeFormat {
 
         if let Some(h12) = self.hour12 {
             hash.aset(ruby.to_symbol("hour12"), h12)?;
+        }
+
+        if let Some(era) = self.era {
+            hash.aset(
+                ruby.to_symbol("era"),
+                ruby.to_symbol(era.to_symbol_name()),
+            )?;
         }
 
         // Add component options if they were used

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -1070,4 +1070,92 @@ RSpec.describe ICU4X::DateTimeFormat do
       end
     end
   end
+
+  describe "era option" do
+    let(:locale) { ICU4X::Locale.parse("en-US") }
+    let(:time) { Time.utc(2025, 12, 28) }
+
+    context "with .new" do
+      %i[auto full with_era never].each do |era|
+        it "creates formatter with era: #{era.inspect}" do
+          formatter = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :numeric, day: :numeric, era:)
+
+          expect(formatter).to be_a(ICU4X::DateTimeFormat)
+        end
+      end
+
+      it "raises ArgumentError for invalid era value" do
+        expect { ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, era: :invalid) }
+          .to raise_error(ArgumentError, /era must be/)
+      end
+    end
+
+    context "with resolved_options" do
+      %i[auto full with_era never].each do |era|
+        it "returns era: #{era.inspect} when specified" do
+          formatter = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :numeric, day: :numeric, era:)
+
+          expect(formatter.resolved_options).to include(era:)
+        end
+      end
+
+      it "does not return era when not specified" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long)
+
+        expect(formatter.resolved_options).not_to have_key(:era)
+      end
+    end
+
+    context "with #format (component options)" do
+      it "formats with era: :with_era including AD for current era" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :numeric, day: :numeric, era: :with_era)
+
+        result = formatter.format(time)
+
+        expect(result).to eq("12/28/2025 AD")
+      end
+
+      it "formats with era: :full showing full century without era" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :numeric, day: :numeric, era: :full)
+
+        result = formatter.format(time)
+
+        expect(result).to eq("12/28/2025")
+      end
+
+      it "formats with era: :auto abbreviating year without era" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :numeric, day: :numeric, era: :auto)
+
+        result = formatter.format(time)
+
+        expect(result).to eq("12/28/25")
+      end
+
+      it "formats with era: :never abbreviating year without era" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :numeric, day: :numeric, era: :never)
+
+        result = formatter.format(time)
+
+        expect(result).to eq("12/28/25")
+      end
+    end
+
+    context "with #format (date_style)" do
+      it "formats with date_style: :long and era: :with_era including AD" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, era: :with_era)
+
+        result = formatter.format(time)
+
+        expect(result).to eq("December 28, 2025 AD")
+      end
+
+      it "formats with date_style: :long without era when era: :never" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, era: :never)
+
+        result = formatter.format(time)
+
+        expect(result).to eq("December 28, 2025")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Add `era:` option to `ICU4X::DateTimeFormat` for controlling whether and how the calendar era is displayed in formatted dates.

## Changes
- Add `EraStyle` enum with `:auto`, `:full`, `:with_era`, `:never` values mapped to ICU4X `YearStyle`
- Apply `with_year_style()` to all year-containing field sets in both component and style formatting paths
- Include `era:` in `resolved_options` output when specified

## Before
- Era display was controlled solely by the calendar and locale; no way to force or suppress era

## After
```ruby
# Always show era (e.g., "12/28/2025 AD")
fmt = ICU4X::DateTimeFormat.new(locale, provider:, year: :numeric, month: :numeric, day: :numeric, era: :with_era)

# Never show era even for ancient dates
fmt = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :long, era: :never)
```

Closes #144
