### PR TITLE
Relax bigdecimal version requirement to >= 3.1, < 5

### DIFF
--- a/icu4x.gemspec
+++ b/icu4x.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/icu4x/extconf.rb"]
 
-  spec.add_dependency "bigdecimal", "~> 4.0"
+  spec.add_dependency "bigdecimal", ">= 3.1", "< 5"
   spec.add_dependency "dry-configurable", "~> 1.3"
   spec.add_dependency "rb_sys", "~> 0.9", ">= 0.9.124"
 end


### PR DESCRIPTION
## Summary

- Change `bigdecimal` dependency from `~> 4.0` to `>= 3.1, < 5`
- This allows icu4x to coexist with gems that require bigdecimal 3.x (e.g. `hanami-utils ~> 2.3` which requires `bigdecimal ~> 3.1`)

## Background

The `~> 4.0` constraint was added in #157 without a functional requirement for bigdecimal 4.x specifically — it was simply the current version at the time. BigDecimal 3.x provides all the functionality icu4x needs (`BigDecimal` class support in `NumberFormat#format`).

## Test plan

- [x] All existing specs pass (`570 examples, 0 failures`)