### PR TITLE
:bug: Fix time_style: :short being ignored when combined with date_style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "icu4x"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "fixed_decimal",
  "icu",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "icu4x_macros"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ext/icu4x/src/datetime_format.rs
+++ b/ext/icu4x/src/datetime_format.rs
@@ -599,11 +599,17 @@ impl DateTimeFormat {
     ) -> CompositeFieldSet {
         match (date_style, time_style) {
             (Some(ds), Some(ts)) => {
-                // Both date and time
-                let ymdt = match (ds, ts) {
-                    (DateStyle::Full, _) | (DateStyle::Long, _) => fieldsets::YMDT::long(),
-                    (DateStyle::Medium, _) => fieldsets::YMDT::medium(),
-                    (DateStyle::Short, _) => fieldsets::YMDT::short(),
+                // Both date and time; date_style determines length
+                let ymdt = match ds {
+                    DateStyle::Full | DateStyle::Long => fieldsets::YMDT::long(),
+                    DateStyle::Medium => fieldsets::YMDT::medium(),
+                    DateStyle::Short => fieldsets::YMDT::short(),
+                };
+                // short time_style suppresses seconds to match Intl.DateTimeFormat behavior
+                let ymdt = if ts == TimeStyle::Short {
+                    ymdt.with_time_precision(TimePrecision::Minute)
+                } else {
+                    ymdt
                 };
                 let ymdt = if let Some(s) = era { ymdt.with_year_style(s.to_icu_year_style()) } else { ymdt };
                 CompositeDateTimeFieldSet::DateTime(DateAndTimeFieldSet::YMDT(ymdt))

--- a/spec/icu4x/datetime_format_spec.rb
+++ b/spec/icu4x/datetime_format_spec.rb
@@ -316,7 +316,26 @@ RSpec.describe ICU4X::DateTimeFormat do
         result = formatter.format(Time.utc(2025, 12, 28, 14, 30, 0))
 
         expect(result).to include("December 28, 2025")
-        expect(result).to include("2:30:00\u202FPM")
+        expect(result).to include("2:30\u202FPM")
+        expect(result).not_to include(":00")
+      end
+
+      it "omits seconds when time_style: :short is combined with date_style: :medium" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :medium, time_style: :short)
+
+        result = formatter.format(Time.utc(2025, 1, 15, 23, 30, 45))
+
+        expect(result).to include("Jan 15, 2025")
+        expect(result).not_to include(":45")
+      end
+
+      it "omits seconds when time_style: :short is combined with date_style and time_zone" do
+        formatter = ICU4X::DateTimeFormat.new(locale, provider:, date_style: :medium, time_style: :short, time_zone: "Asia/Tokyo")
+
+        result = formatter.format(Time.utc(2025, 1, 15, 23, 30, 45))
+
+        expect(result).to include("Jan 16, 2025")
+        expect(result).not_to include(":45")
       end
     end
 
@@ -551,7 +570,8 @@ RSpec.describe ICU4X::DateTimeFormat do
         result = formatter.format(Time.utc(2025, 12, 28, 23, 30, 0))
 
         expect(result).to include("December 29, 2025")
-        expect(result).to include("8:30:00\u202FAM")
+        expect(result).to include("8:30\u202FAM")
+        expect(result).not_to include(":00")
       end
     end
 


### PR DESCRIPTION
## Summary

`time_style: :short` was being ignored when `date_style` was also specified — the output included seconds as if `time_style: :medium` were used. The fix applies `TimePrecision::Minute` in the date+time branch, matching the behavior already in place for the time-only branch.

## Changes

- Apply `with_time_precision(TimePrecision::Minute)` for `time_style: :short` in the `(Some(ds), Some(ts))` branch of `create_field_set_from_style`
- Correct existing test expectations that reflected the buggy behavior
- Add tests for `:short` combined with `date_style: :medium` and with `time_zone`

## Before / After

```ruby
fmt = ICU4X::DateTimeFormat.new(locale, date_style: :medium, time_style: :short)
fmt.format(Time.utc(2025, 1, 15, 23, 30, 45))
# Before: "Jan 15, 2025, 11:30:45 PM"  (seconds incorrectly included)
# After:  "Jan 15, 2025, 11:30 PM"
```

Fixes #161
